### PR TITLE
fix(ui): improve AgentCard extension handling and visualization

### DIFF
--- a/common/auth/agent_credential_service.py
+++ b/common/auth/agent_credential_service.py
@@ -298,6 +298,14 @@ class CustomAuthInterceptor(ClientCallInterceptor):
                         "[CustomAuth] Set Bearer header for scheme '%s'",
                         scheme_name,
                     )
+
+                accept_header = scheme_cfg.get("accept_header")
+                if accept_header:
+                    args.context.service_parameters["Accept"] = accept_header
+                    logger.info(
+                        "[AgentAuth] Override Accept header to '%s' for agent '%s'",
+                        accept_header, getattr(args.agent_card, 'name', 'unknown'),
+                    )
                 return
 
     async def after(self, args: AfterArgs) -> None:

--- a/common/auth/extension_interceptor.py
+++ b/common/auth/extension_interceptor.py
@@ -19,7 +19,7 @@ from typing import List
 
 from a2a.client.interceptors import ClientCallInterceptor, BeforeArgs, AfterArgs
 from a2a.client.client import ClientCallContext
-from a2a.extensions.common import HTTP_EXTENSION_HEADER
+from a2a.extensions.common import HTTP_EXTENSION_HEADER, get_requested_extensions
 from loguru import logger
 
 
@@ -28,6 +28,9 @@ class ExtensionInterceptor(ClientCallInterceptor):
 
     Reads the agent's declared extensions (from capabilities.extensions[].uri) and
     sets the A2A-Extensions header so the server knows which extensions the client supports.
+
+    Uses the official a2a-sdk `get_requested_extensions()` utility for safe URI
+    merging and deduplication, per the A2A protocol specification.
     """
 
     def __init__(self, extension_uris: List[str]):
@@ -44,9 +47,9 @@ class ExtensionInterceptor(ClientCallInterceptor):
             args.context.service_parameters = {}
 
         existing = args.context.service_parameters.get(HTTP_EXTENSION_HEADER, "")
-        existing_uris = set(e.strip() for e in existing.split(",") if e.strip())
-        all_uris = sorted(existing_uris | set(self._uris))
-        args.context.service_parameters[HTTP_EXTENSION_HEADER] = ",".join(all_uris)
+        existing_values = [existing] if existing else []
+        merged = sorted(get_requested_extensions([*existing_values, *self._uris]))
+        args.context.service_parameters[HTTP_EXTENSION_HEADER] = ",".join(merged)
 
         logger.debug(
             f"[Extensions] Set {HTTP_EXTENSION_HEADER}={args.context.service_parameters[HTTP_EXTENSION_HEADER]}"

--- a/common/auth/extension_interceptor.py
+++ b/common/auth/extension_interceptor.py
@@ -49,10 +49,12 @@ class ExtensionInterceptor(ClientCallInterceptor):
         existing = args.context.service_parameters.get(HTTP_EXTENSION_HEADER, "")
         existing_values = [existing] if existing else []
         merged = sorted(get_requested_extensions([*existing_values, *self._uris]))
-        args.context.service_parameters[HTTP_EXTENSION_HEADER] = ",".join(merged)
+        extension_value = ",".join(merged)
+        args.context.service_parameters[HTTP_EXTENSION_HEADER] = extension_value
+        args.context.service_parameters["x-a2a-extensions"] = extension_value
 
-        logger.debug(
-            f"[Extensions] Set {HTTP_EXTENSION_HEADER}={args.context.service_parameters[HTTP_EXTENSION_HEADER]}"
+        logger.info(
+            f"[Extensions] Set {HTTP_EXTENSION_HEADER}={extension_value} (also x-a2a-extensions)"
         )
 
     async def after(self, args: AfterArgs) -> None:

--- a/common/negotiation_utils.py
+++ b/common/negotiation_utils.py
@@ -18,7 +18,7 @@
 from typing import Dict, Any, Optional
 from loguru import logger
 
-from a2a_t.negotiation.common.enums import NegotiationType, NegotiationStatus, NegotiationRole
+from a2a_t.negotiation.common.enums import NegotiationType, NegotiationStatus
 from a2a_t.negotiation.common.models import NegotiationContext
 
 
@@ -29,7 +29,7 @@ TASK_PROMPT_KEY = "https://github.com/a2aproject/telecommunication/extensions/Ta
 NEGOTIATION_RESOLUTION_MARKER = "[NEGOTIATION_RESOLUTION]"
 NEGOTIATION_REQUEST_MARKER = "[NEGOTIATION_REQUEST]"
 NEGOTIATION_CONTEXT_MARKER = "[NEGOTIATION_CONTEXT]"
-_NEGOTIATION_MAX_ROUNDS = 5
+NEGOTIATION_CONCERN_KEY = "negotiationConcern"
 
 
 def extract_negotiation_context_from_task_metadata(
@@ -66,17 +66,6 @@ def extract_negotiation_context_from_artifact_metadata(
         return None
 
 
-def build_negotiation_metadata(
-    negotiation_result: Dict[str, Any]
-) -> Dict[str, Any]:
-    context_data = negotiation_result.get(NEGOTIATION_CONTEXT_KEY)
-    if not context_data:
-        logger.warning("No negotiation context in result")
-        return {}
-
-    return {NEGOTIATION_CONTEXT_KEY: context_data}
-
-
 def build_negotiation_response_metadata(
     negotiation_context_data: Optional[Dict[str, Any]],
     negotiation_text: Optional[str],
@@ -88,7 +77,7 @@ def build_negotiation_response_metadata(
     if negotiation_text:
         metadata[NEGOTIATION_TEXT_KEY] = negotiation_text
     if negotiation_concern:
-        metadata["negotiationConcern"] = negotiation_concern
+        metadata[NEGOTIATION_CONCERN_KEY] = negotiation_concern
     return metadata
 
 
@@ -179,11 +168,11 @@ def build_negotiation_resolution_task(
         "",
         f"{resolution_text}",
         "",
-        f"---",
-        f"Original Task:",
+        "---",
+        "Original Task:",
         f"{original_task}",
         "",
-        f"Please re-execute the task based on the clarification above.",
+        "Please re-execute the task based on the clarification above.",
     ]
     if continued_context:
         import json as _json

--- a/common/negotiation_utils.py
+++ b/common/negotiation_utils.py
@@ -38,7 +38,7 @@ def extract_negotiation_context_from_task_metadata(
     if not task_metadata:
         return None
 
-    context_data = task_metadata.get("negotiationContext")
+    context_data = task_metadata.get(NEGOTIATION_CONTEXT_KEY)
     if not context_data:
         return None
 
@@ -55,7 +55,7 @@ def extract_negotiation_context_from_artifact_metadata(
     if not artifact_metadata:
         return None
 
-    context_data = artifact_metadata.get("negotiationContext")
+    context_data = artifact_metadata.get(NEGOTIATION_CONTEXT_KEY)
     if not context_data:
         return None
 
@@ -74,7 +74,22 @@ def build_negotiation_metadata(
         logger.warning("No negotiation context in result")
         return {}
 
-    return {"negotiationContext": context_data}
+    return {NEGOTIATION_CONTEXT_KEY: context_data}
+
+
+def build_negotiation_response_metadata(
+    negotiation_context_data: Optional[Dict[str, Any]],
+    negotiation_text: Optional[str],
+    negotiation_concern: Optional[str] = None,
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    if negotiation_context_data:
+        metadata[NEGOTIATION_CONTEXT_KEY] = negotiation_context_data
+    if negotiation_text:
+        metadata[NEGOTIATION_TEXT_KEY] = negotiation_text
+    if negotiation_concern:
+        metadata["negotiationConcern"] = negotiation_concern
+    return metadata
 
 
 def is_negotiation_in_progress(context: NegotiationContext) -> bool:
@@ -148,8 +163,8 @@ Reply with exactly one word: YES or NO."""
 def extract_negotiation_content(task_metadata: Dict[str, Any]) -> tuple[Optional[str], Optional[dict]]:
     if not task_metadata:
         return None, None
-    negotiation_text = task_metadata.get("negotiationText")
-    context_data = task_metadata.get("negotiationContext")
+    negotiation_text = task_metadata.get(NEGOTIATION_TEXT_KEY)
+    context_data = task_metadata.get(NEGOTIATION_CONTEXT_KEY)
     return negotiation_text, context_data
 
 

--- a/orchestrate/agentcard_loader.py
+++ b/orchestrate/agentcard_loader.py
@@ -42,6 +42,9 @@ def _normalize_security_schemes(sec_schemes: Dict[str, Any]) -> Dict[str, Any]:
             continue
         if "scheme" in scheme and isinstance(scheme["scheme"], str):
             http_auth = {"scheme": scheme["scheme"]}
+            for extra_key in ("description", "bearerFormat"):
+                if extra_key in scheme:
+                    http_auth[extra_key] = scheme[extra_key]
             normalized[name] = {"httpAuthSecurityScheme": http_auth}
             continue
         if scheme.get("type") == "apiKey":

--- a/orchestrate/registry_client/client.py
+++ b/orchestrate/registry_client/client.py
@@ -70,11 +70,17 @@ class AgentRegistryClient:
         data = MessageToDict(agent)
         resp = await self._request('PUT', f'/rest/v1/registry-center/agent-cards/{organization}/{name}',
                              json={"agentCards":[data]})
-        return resp.json()
+        try:
+            return resp.json()
+        except Exception:
+            return resp.status_code in (200, 201, 204)
 
     async def deregister(self, name: str, organization: str) -> bool:
         resp = await self._request('DELETE', f'/rest/v1/registry-center/agent-cards/{organization}/{name}')
-        return resp.json()
+        try:
+            return resp.json()
+        except Exception:
+            return resp.status_code in (200, 201, 204)
 
     async def get(self, name: str, organization: str) -> dict | None:
         resp = await self._request('GET', f'/rest/v1/registry-center/agent-cards/{organization}/{name}')

--- a/orchestrate/runtime/exec_engine.py
+++ b/orchestrate/runtime/exec_engine.py
@@ -441,8 +441,8 @@ class DynamicWorkflowEngine:
         })
 
     def _push_negotiation_event(self, agent_name: str, metadata_dict: Dict[str, Any], round_num: int):
-        from common.negotiation_utils import NEGOTIATION_CONTEXT_KEY
-        concern = metadata_dict.get("negotiationConcern", "")
+        from common.negotiation_utils import NEGOTIATION_CONTEXT_KEY, NEGOTIATION_CONCERN_KEY
+        concern = metadata_dict.get(NEGOTIATION_CONCERN_KEY, "")
         context_data = metadata_dict.get(NEGOTIATION_CONTEXT_KEY) or {}
         self._push_event("negotiation_request", {
             "agent": agent_name,
@@ -470,6 +470,7 @@ class DynamicWorkflowEngine:
             extract_negotiation_content,
             build_negotiation_resolution_task,
             NEGOTIATION_CONTEXT_KEY,
+            NEGOTIATION_CONCERN_KEY,
             extract_original_task_from_follow_up,
         )
 
@@ -478,7 +479,7 @@ class DynamicWorkflowEngine:
 
         negotiation_text, context_data = extract_negotiation_content(metadata_dict)
         if not negotiation_text or not context_data:
-            negotiation_concern = metadata_dict.get("negotiationConcern", "")
+            negotiation_concern = metadata_dict.get(NEGOTIATION_CONCERN_KEY, "")
             if negotiation_concern:
                 negotiation_text = negotiation_concern
             else:

--- a/orchestrate/runtime/exec_engine.py
+++ b/orchestrate/runtime/exec_engine.py
@@ -232,6 +232,13 @@ class DynamicWorkflowEngine:
         uris = self._get_task_t_uris(agent_card)
         return uris[0] if uris else None
 
+    def _supports_negotiation(self, agent_card) -> bool:
+        if getattr(agent_card, 'capabilities', None) and agent_card.capabilities.extensions:
+            for ext in agent_card.capabilities.extensions:
+                if ext.uri and 'NEGOTIATION-T' in ext.uri:
+                    return True
+        return False
+
     async def send_message_to_agent(self, agent_name: str, task: str, httpx_client=None):
         return await self._send_with_negotiation(agent_name, task, httpx_client)
 
@@ -244,6 +251,16 @@ class DynamicWorkflowEngine:
             task_state = task_result.status.state
             from a2a.types import TaskState as TS
             if task_state == TS.TASK_STATE_INPUT_REQUIRED:
+                agent_card = self._agent_map.get(agent_name)
+                if not agent_card or not self._supports_negotiation(agent_card):
+                    logger.warning(
+                        f"Agent '{agent_name}' returned INPUT_REQUIRED but does not declare"
+                        f" NEGOTIATION-T extension. Returning response text as-is."
+                    )
+                    if response_text is not None:
+                        return response_text
+                    return ""
+
                 if _round >= self._NEGOTIATION_MAX_ROUNDS:
                     logger.error(
                         f"Negotiation with agent '{agent_name}' reached max rounds ({self._NEGOTIATION_MAX_ROUNDS}) "
@@ -294,16 +311,12 @@ class DynamicWorkflowEngine:
         except ImportError:
             pass
 
-        if self.a2at_client and not skip_prompt_gen:
+        if self.a2at_client and task_t_uri and not skip_prompt_gen:
             try:
                 prompt_result = self.a2at_client.generate_task_prompt(task)
                 if prompt_result.success and prompt_result.prompt_text:
-                    if task_t_uri:
-                        task_t_metadata = prompt_result.prompt_text
-                        logger.info(f"[A2AT] Generated TASK-T prompt for agent '{agent_name}', will set in metadata")
-                    else:
-                        task_text = prompt_result.prompt_text
-                        logger.info(f"[A2AT] Generated task prompt for agent '{agent_name}'")
+                    task_t_metadata = prompt_result.prompt_text
+                    logger.info(f"[A2AT] Generated TASK-T prompt for agent '{agent_name}', will set in metadata")
                 else:
                     logger.warning(f"[A2AT] Task prompt generation failed, using original task")
             except Exception as e:

--- a/orchestrate/runtime/exec_engine.py
+++ b/orchestrate/runtime/exec_engine.py
@@ -151,7 +151,9 @@ class DynamicWorkflowEngine:
                 if cred_svc is not None:
                     agent_cfg = auth_manager.get_config(card.name) or {}
                     if any(
-                        isinstance(v, dict) and v.get("auth_header")
+                        isinstance(v, dict) and (
+                            v.get("auth_header") or v.get("accept_header")
+                        )
                         for v in agent_cfg.values()
                     ):
                         interceptors.append(CustomAuthInterceptor(cred_svc, agent_cfg))
@@ -175,7 +177,17 @@ class DynamicWorkflowEngine:
     def _get_httpx_client(self) -> httpx.AsyncClient:
         if self._httpx_client is None:
             timeout_config = httpx.Timeout(connect=60, read=60, write=60, pool=10.0)
-            self._httpx_client = httpx.AsyncClient(timeout=timeout_config, verify=False, follow_redirects=True)
+
+            async def _log_request(request: httpx.Request):
+                logger.info(
+                    f"[HTTP] >>> {request.method} {request.url}  "
+                    f"headers={dict(request.headers)}"
+                )
+
+            self._httpx_client = httpx.AsyncClient(
+                timeout=timeout_config, verify=False, follow_redirects=True,
+                event_hooks={"request": [_log_request]},
+            )
             auth_manager = get_auth_manager()
             auth_manager.set_httpx_client(self._httpx_client)
         return self._httpx_client
@@ -383,7 +395,14 @@ class DynamicWorkflowEngine:
                 if iface.protocol_binding
             ] or ["HTTP+JSON", "JSONRPC"]
             selected_url = agent_card.supported_interfaces[0].url if agent_card.supported_interfaces else "N/A"
-            logger.info(f"Calling agent '{agent_name}' via {protocol_bindings[0] if protocol_bindings else 'unknown'} -> {selected_url}")
+            streaming = agent_card.capabilities.streaming if agent_card.capabilities else False
+            proto = protocol_bindings[0] if protocol_bindings else 'unknown'
+            if proto == "HTTP+JSON":
+                endpoint = "message:stream" if streaming else "message:send"
+                full_url = f"{selected_url}/{endpoint}"
+            else:
+                full_url = selected_url
+            logger.info(f"Calling agent '{agent_name}' via {proto} (streaming={streaming}) -> {full_url}")
             config = ClientConfig(
                 httpx_client=client,
                 supported_protocol_bindings=protocol_bindings,
@@ -401,11 +420,12 @@ class DynamicWorkflowEngine:
                 request_msg.metadata.CopyFrom(meta)
                 logger.info(f"[A2AT] Set TASK-T metadata on message for agent '{agent_name}'")
             send_req = SendMessageRequest(message=request_msg)
-            send_req_json = MessageToJson(send_req, preserving_proto_field_name=True)
-            try:
-                req_payload = json.loads(send_req_json)
-            except (json.JSONDecodeError, TypeError):
-                req_payload = send_req_json
+            req_payload = json.loads(MessageToJson(send_req, preserving_proto_field_name=False))
+            logger.info(
+                f"[A2A] Sending to agent '{agent_name}': "
+                f"url={full_url}, "
+                f"body={json.dumps(req_payload, ensure_ascii=False)}"
+            )
             self._push_event("agent_request", {
                 "agent": agent_name,
                 "request": req_payload
@@ -419,7 +439,7 @@ class DynamicWorkflowEngine:
 
             async for response in client.send_message(send_req):
                 try:
-                    raw_resp = MessageToJson(response, preserving_proto_field_name=True)
+                    raw_resp = MessageToJson(response, preserving_proto_field_name=False)
                     resp_payload = json.loads(raw_resp) if raw_resp != "{}" else raw_resp
                 except Exception:
                     resp_payload = str(response)

--- a/orchestrate/runtime/exec_engine.py
+++ b/orchestrate/runtime/exec_engine.py
@@ -40,6 +40,60 @@ except ImportError:
     _A2AT_AVAILABLE = False
     A2ATClient = None
 
+import google.protobuf.json_format as _json_format
+
+_original_parse = _json_format.Parse
+
+_STREAM_RESPONSE_KEYS = frozenset({"task", "message", "statusUpdate", "artifactUpdate"})
+
+
+def _normalize_stream_response(data: dict) -> dict:
+    if _STREAM_RESPONSE_KEYS.intersection(data):
+        return data
+    if "id" in data and "status" in data:
+        return {"task": data}
+    if "artifact" in data and "taskId" in data:
+        return {"artifactUpdate": data}
+    if "status" in data and "taskId" in data:
+        return {"statusUpdate": data}
+    return data
+
+
+def _parse_with_unknown(text, message, ignore_unknown_fields=False, **kwargs):
+    from a2a.types.a2a_pb2 import StreamResponse
+    if isinstance(message, StreamResponse):
+        try:
+            import json as _json
+            data = _json.loads(text)
+            if isinstance(data, dict):
+                if not _STREAM_RESPONSE_KEYS.intersection(data):
+                    logger.warning(f"[A2A] Non-SSE response from server: {text[:2048]}")
+                data = _normalize_stream_response(data)
+                text = _json.dumps(data)
+        except Exception:
+            pass
+    return _original_parse(text, message, ignore_unknown_fields=True, **kwargs)
+
+
+_original_parse_dict = _json_format.ParseDict
+
+
+def _parse_dict_with_unknown(js, message, *args, **kwargs):
+    from a2a.types.a2a_pb2 import StreamResponse
+    if isinstance(message, StreamResponse) and isinstance(js, dict):
+        js = _normalize_stream_response(js)
+    kwargs.pop("ignore_unknown_fields", None)
+    args = list(args)
+    if args:
+        args[0] = True
+    else:
+        kwargs["ignore_unknown_fields"] = True
+    return _original_parse_dict(js, message, *args, **kwargs)
+
+
+_json_format.Parse = _parse_with_unknown
+_json_format.ParseDict = _parse_dict_with_unknown
+
 from common.llm import get_llm_instance
 from common.auth import get_auth_manager
 from common.auth.agent_credential_service import CustomAuthInterceptor

--- a/orchestrate/runtime/exec_engine.py
+++ b/orchestrate/runtime/exec_engine.py
@@ -428,8 +428,9 @@ class DynamicWorkflowEngine:
         })
 
     def _push_negotiation_event(self, agent_name: str, metadata_dict: Dict[str, Any], round_num: int):
+        from common.negotiation_utils import NEGOTIATION_CONTEXT_KEY
         concern = metadata_dict.get("negotiationConcern", "")
-        context_data = metadata_dict.get("negotiationContext", {})
+        context_data = metadata_dict.get(NEGOTIATION_CONTEXT_KEY) or {}
         self._push_event("negotiation_request", {
             "agent": agent_name,
             "response": json.dumps({

--- a/samples/agentcard/assurance_agent.json
+++ b/samples/agentcard/assurance_agent.json
@@ -33,8 +33,18 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }
       ]

--- a/samples/agentcard/energy_saving_intent_agent.json
+++ b/samples/agentcard/energy_saving_intent_agent.json
@@ -55,8 +55,18 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }
       ]

--- a/samples/agentcard/live_streaming_agent.json
+++ b/samples/agentcard/live_streaming_agent.json
@@ -33,8 +33,18 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }
       ]

--- a/samples/agentcard/ran_agent.json
+++ b/samples/agentcard/ran_agent.json
@@ -42,8 +42,18 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }
       ]

--- a/samples/agentcard/ran_energy_saving_agent.json
+++ b/samples/agentcard/ran_energy_saving_agent.json
@@ -45,8 +45,18 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }
       ]

--- a/samples/agentcard/spn_agent_card.json
+++ b/samples/agentcard/spn_agent_card.json
@@ -1,53 +1,83 @@
-[{
-		"name": "SPN Domain Agent",
-		"description": "SPN Domain Agent (external agent card template — for reference only)",
-		"provider": {
-			"organization": "Huawei",
-			"url": "https://www.huawei.com"
-		},
-		"version": "1.0.0",
-		"capabilities": {
-			"streaming": true,
-			"pushNotifications": false,
-			"extendedAgentCard": false,
-			"extensions": [{
-				"description": "Extension of structured prompt TASK-T requests.",
-				"required": false,
-				"uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1"
-			}]
-		},
-		"defaultInputModes": ["application/json",
-		"text/plain"],
-		"defaultOutputModes": ["application/json",
-		"text/plain"],
-		"skills": [{
-			"id": "SPN-private-line-service-complain-diagnosis",
-			"name": "SPN专线业务投诉诊断",
-			"description": "提供SPN领域专线业务网络侧故障根因诊断能力",
-			"tags": ["SPN专线业务投诉诊断"],
-			"examples": ["## Task Type\\nSPN专线投诉诊断\\n## Task Description\\n要求：提供任务的整体概述，基于<Task Object>、<Task Context>进行投诉场景的网络侧故障根因诊断, 达成<Task Target>中定义的投诉诊断目标，按照<Expected Output>中定义的结构返回任务处理结果。\\n## Task Target\\n基于专线业务的故障现象，诊断并返回网络侧的故障根因\\n## Task Object\\n接入端口资源ID：f47ac10b-58cc-4372-a567-0e02b2c3d479\\n## Task Context\\n1. 故障场景：\"专线中断\"\\n2. 故障发生时间：\"2024-01-16T08: 21: 46Z\"\\n3. OSS侧事件流水号：\"fault-id-1-017-20230511-09013\"\\n## Expected Output\\n要求：\\n1. 包含诊断结果类型，诊断结果详细信息，修复建议。\\n2. 诊断结果类型参数的取值范围包括：诊断成功、诊断失败、诊断未开始或者诊断未结束\\n3. 可以包括多个故障根因，每个故障根因包含故障根因的名称、详细描述、修复建议，故障根因点所在资源对象的标识、类型，名称，详细位置等信息。如果存在多故障根因，需要将每个故障根因中的详细描述和修复建议总结提炼到整体的诊断结果详细信息和修复建议。"],
-			"inputModes": ["application/json",
-			"text/plain"],
-			"outputModes": ["application/json",
-			"text/plain"]
-		}],
-		"securitySchemes": {
-			"bearerAuth": {
-				"scheme": "Bearer",
-				"description": "使用用户名和密码通过登录接口查询accessSession后，使用该accessSession进行bearer认证。"
-			}
-		},
-		"securityRequirements": [],
-		"supportedInterfaces": [{
-			"protocolBinding": "JSONRPC",
-			"url": "http://127.0.0.1:26335/a2a/v1",
-			"tenant": "",
-			"protocolVersion": "1.0"
-		},
-		{
-			"protocolBinding": "HTTP+JSON",
-			"url": "http://127.0.0.1:26335/a2a/json",
-			"tenant": "",
-			"protocolVersion": "1.0"
-		}]
-}]
+[
+  {
+    "name": "SPN Domain Agent",
+    "description": "SPN Domain Agent (external agent card template — for reference only)",
+    "provider": {
+      "organization": "Huawei",
+      "url": "https://www.huawei.com"
+    },
+    "version": "1.0.0",
+    "capabilities": {
+      "streaming": true,
+      "pushNotifications": false,
+      "extendedAgentCard": false,
+      "extensions": [
+        {
+          "description": "Extension of structured prompt TASK-T requests.",
+          "required": false,
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1"
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
+          "required": false
+        }
+      ]
+    },
+    "defaultInputModes": [
+      "application/json",
+      "text/plain"
+    ],
+    "defaultOutputModes": [
+      "application/json",
+      "text/plain"
+    ],
+    "skills": [
+      {
+        "id": "SPN-private-line-service-complain-diagnosis",
+        "name": "SPN专线业务投诉诊断",
+        "description": "提供SPN领域专线业务网络侧故障根因诊断能力",
+        "tags": [
+          "SPN专线业务投诉诊断"
+        ],
+        "examples": [
+          "## Task Type\\nSPN专线投诉诊断\\n## Task Description\\n要求：提供任务的整体概述，基于<Task Object>、<Task Context>进行投诉场景的网络侧故障根因诊断, 达成<Task Target>中定义的投诉诊断目标，按照<Expected Output>中定义的结构返回任务处理结果。\\n## Task Target\\n基于专线业务的故障现象，诊断并返回网络侧的故障根因\\n## Task Object\\n接入端口资源ID：f47ac10b-58cc-4372-a567-0e02b2c3d479\\n## Task Context\\n1. 故障场景：\"专线中断\"\\n2. 故障发生时间：\"2024-01-16T08: 21: 46Z\"\\n3. OSS侧事件流水号：\"fault-id-1-017-20230511-09013\"\\n## Expected Output\\n要求：\\n1. 包含诊断结果类型，诊断结果详细信息，修复建议。\\n2. 诊断结果类型参数的取值范围包括：诊断成功、诊断失败、诊断未开始或者诊断未结束\\n3. 可以包括多个故障根因，每个故障根因包含故障根因的名称、详细描述、修复建议，故障根因点所在资源对象的标识、类型，名称，详细位置等信息。如果存在多故障根因，需要将每个故障根因中的详细描述和修复建议总结提炼到整体的诊断结果详细信息和修复建议。"
+        ],
+        "inputModes": [
+          "application/json",
+          "text/plain"
+        ],
+        "outputModes": [
+          "application/json",
+          "text/plain"
+        ]
+      }
+    ],
+    "securitySchemes": {
+      "bearerAuth": {
+        "scheme": "Bearer",
+        "description": "使用用户名和密码通过登录接口查询accessSession后，使用该accessSession进行bearer认证。"
+      }
+    },
+    "securityRequirements": [],
+    "supportedInterfaces": [
+      {
+        "protocolBinding": "JSONRPC",
+        "url": "http://127.0.0.1:26335/a2a/v1",
+        "tenant": "",
+        "protocolVersion": "1.0"
+      },
+      {
+        "protocolBinding": "HTTP+JSON",
+        "url": "http://127.0.0.1:26335/a2a/json",
+        "tenant": "",
+        "protocolVersion": "1.0"
+      }
+    ]
+  }
+]

--- a/samples/agentcard/spn_agent_card.json
+++ b/samples/agentcard/spn_agent_card.json
@@ -60,11 +60,19 @@
     ],
     "securitySchemes": {
       "bearerAuth": {
-        "scheme": "Bearer",
-        "description": "使用用户名和密码通过登录接口查询accessSession后，使用该accessSession进行bearer认证。"
+        "httpAuthSecurityScheme": {
+          "scheme": "Bearer",
+          "description": "使用用户名和密码通过登录接口查询accessSession后，使用该accessSession进行bearer认证。"
+        }
       }
     },
-    "securityRequirements": [],
+    "securityRequirements": [
+      {
+        "schemes": {
+          "bearerAuth": {}
+        }
+      }
+    ],
     "supportedInterfaces": [
       {
         "protocolBinding": "JSONRPC",

--- a/samples/agentcard/spn_fault_handling_agent_city1_omc.json
+++ b/samples/agentcard/spn_fault_handling_agent_city1_omc.json
@@ -24,8 +24,18 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }
       ]

--- a/samples/agentcard/spn_fault_handling_agent_city2_omc.json
+++ b/samples/agentcard/spn_fault_handling_agent_city2_omc.json
@@ -24,8 +24,18 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }
       ]

--- a/samples/agentcard/transport_workbench_agent.json
+++ b/samples/agentcard/transport_workbench_agent.json
@@ -33,8 +33,18 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }
       ]

--- a/samples/agentcard/uncertainty_simulation_agent.json
+++ b/samples/agentcard/uncertainty_simulation_agent.json
@@ -25,8 +25,18 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "description": "Extension for A2A-T negotiation text exchange.",
+          "required": false
+        },
+        {
+          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }
       ]

--- a/samples/agentcard/workbench_platform_agent_card.json
+++ b/samples/agentcard/workbench_platform_agent_card.json
@@ -10,7 +10,23 @@
 			"streaming": true,
 			"pushNotifications": false,
 			"extendedAgentCard": false,
-			"extensions": []
+			"extensions": [
+				{
+					"uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+					"description": "Extension of structured prompt TASK-T requests.",
+					"required": false
+				},
+				{
+					"uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+					"description": "Extension for A2A-T negotiation text exchange.",
+					"required": false
+				},
+				{
+					"uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+					"description": "Extension for A2A-T negotiation context data.",
+					"required": false
+				}
+			]
 		},
 		"defaultInputModes": ["application/json",
 		"text/plain"],

--- a/samples/agentcard/workbench_platform_agent_card.json
+++ b/samples/agentcard/workbench_platform_agent_card.json
@@ -45,11 +45,19 @@
 		}],
 		"securitySchemes": {
 			"bearerAuth": {
-				"scheme": "Bearer",
-				"description": "使用用户名和密码通过OAuth2 Password Grant接口获取access_token后，使用fmind-auth头部进行认证。"
+				"httpAuthSecurityScheme": {
+					"scheme": "Bearer",
+					"description": "使用用户名和密码通过OAuth2 Password Grant接口获取access_token后，使用fmind-auth头部进行认证。"
+				}
 			}
 		},
-		"securityRequirements": [],
+		"securityRequirements": [
+			{
+				"schemes": {
+					"bearerAuth": {}
+				}
+			}
+		],
 		"supportedInterfaces": [{
 			"protocolBinding": "JSONRPC",
 			"url": "http://127.0.0.1:26336/a2a/v1",

--- a/samples/agentcard/workbench_platform_agent_card.json
+++ b/samples/agentcard/workbench_platform_agent_card.json
@@ -45,9 +45,14 @@
 		}],
 		"securitySchemes": {
 			"bearerAuth": {
-				"httpAuthSecurityScheme": {
-					"scheme": "Bearer",
-					"description": "使用用户名和密码通过OAuth2 Password Grant接口获取access_token后，使用fmind-auth头部进行认证。"
+				"oauth2SecurityScheme": {
+					"description": "OAuth2 Password Grant — 通过 /oauth/token 接口获取 access_token，使用 fmind-auth 头部进行认证",
+					"flows": {
+						"password": {
+							"token_url": "http://<YOUR_HOST>:<YOUR_PORT>/bgw/cswg-service/oauth/token",
+							"scopes": {}
+						}
+					}
 				}
 			}
 		},

--- a/samples/agents/negotiation_base_agent.py
+++ b/samples/agents/negotiation_base_agent.py
@@ -34,7 +34,6 @@ from common.negotiation_utils import (
     NEGOTIATION_TEXT_KEY,
     TASK_PROMPT_KEY,
     NEGOTIATION_REQUEST_MARKER,
-    build_negotiation_metadata,
     build_negotiation_response_metadata,
     log_negotiation_context,
     is_uncertain_response,

--- a/samples/agents/negotiation_base_agent.py
+++ b/samples/agents/negotiation_base_agent.py
@@ -32,8 +32,10 @@ from common.llm import get_llm_instance
 from common.negotiation_utils import (
     NEGOTIATION_CONTEXT_KEY,
     NEGOTIATION_TEXT_KEY,
+    TASK_PROMPT_KEY,
     NEGOTIATION_REQUEST_MARKER,
     build_negotiation_metadata,
+    build_negotiation_response_metadata,
     log_negotiation_context,
     is_uncertain_response,
     is_follow_up_task,
@@ -61,7 +63,7 @@ class NegotiationBaseAgentExecutor(AgentExecutor):
         ctx_id = context.context_id or "N/A"
         logger.info(f"[{self.__class__.__name__}] execute: task_id={task_id}, context_id={ctx_id}")
 
-        task_t_uri = "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1"
+        task_t_uri = TASK_PROMPT_KEY
         try:
             if hasattr(context, 'message') and context.message:
                 msg = context.message
@@ -97,12 +99,11 @@ class NegotiationBaseAgentExecutor(AgentExecutor):
         uncertain = await asyncio.to_thread(is_uncertain_response, response, self.llm)
         if uncertain:
             logger.info(f"[{self.__class__.__name__}] Response indicates uncertainty, requesting negotiation")
-            metadata: Dict[str, Any] = {}
-            if negotiation_context_data:
-                metadata["negotiationContext"] = negotiation_context_data
-            if negotiation_text:
-                metadata["negotiationText"] = negotiation_text
-            metadata["negotiationConcern"] = response
+            metadata = build_negotiation_response_metadata(
+                negotiation_context_data=negotiation_context_data,
+                negotiation_text=negotiation_text,
+                negotiation_concern=response,
+            )
             return Task(
                 id=context.task_id,
                 context_id=context.context_id,
@@ -195,9 +196,10 @@ class NegotiationBaseAgentExecutor(AgentExecutor):
         response: str,
         negotiation_context: Dict[str, Any]
     ) -> Task:
-        metadata: Dict[str, Any] = {}
-        if negotiation_context:
-            metadata["negotiationContext"] = negotiation_context
+        metadata = build_negotiation_response_metadata(
+            negotiation_context_data=negotiation_context if negotiation_context else None,
+            negotiation_text=None,
+        )
 
         return Task(
             id=context.task_id,

--- a/test/test_exec_engine.py
+++ b/test/test_exec_engine.py
@@ -1279,7 +1279,7 @@ class TestNegotiationFlow:
         task.status = status
         task.metadata = {
             "negotiationConcern": "I need more information about the target",
-            "negotiationContext": {
+            "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1": {
                 "negotiationType": "fulfillment",
                 "negotiationId": "neg-001",
                 "role": "client",
@@ -1325,7 +1325,7 @@ class TestNegotiationFlow:
             "message": "Acknowledged",
         }
         mock.continue_negotiation.return_value = {
-            "negotiationContext": {
+            "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1": {
                 "negotiationType": "fulfillment",
                 "negotiationId": "neg-001",
                 "round": 1,

--- a/workflow-designer/package-lock.json
+++ b/workflow-designer/package-lock.json
@@ -23,6 +23,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^16.5.8",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.1",
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1"
@@ -1962,8 +1963,25 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1991,7 +2009,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2018,6 +2035,12 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.2",
@@ -2769,6 +2792,36 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2867,6 +2920,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -2987,7 +3050,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -3709,6 +3771,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4345,6 +4417,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4386,6 +4498,16 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-errors": {
@@ -4533,6 +4655,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -4562,6 +4690,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4589,6 +4741,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-docker": {
@@ -4628,6 +4790,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-in-ssh": {
@@ -5466,6 +5638,66 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -5474,6 +5706,27 @@
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6425,6 +6678,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6748,6 +7026,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6902,6 +7190,33 @@
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
@@ -7086,6 +7401,23 @@
         "mdast-util-from-markdown": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7498,6 +7830,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -7541,6 +7883,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -7568,6 +7924,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -7793,6 +8167,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -7899,6 +8283,19 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"

--- a/workflow-designer/package.json
+++ b/workflow-designer/package.json
@@ -26,6 +26,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^16.5.8",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1"

--- a/workflow-designer/src/components/registry_center/agentcard_visualization/index.jsx
+++ b/workflow-designer/src/components/registry_center/agentcard_visualization/index.jsx
@@ -16,6 +16,18 @@
 //    under the License.
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+const unescapeJsonString = (str) => {
+    if (!str || typeof str !== 'string') return str;
+    return str
+        .replace(/\\n/g, '\n')
+        .replace(/\\t/g, '\t')
+        .replace(/\\r/g, '\r')
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, '\\');
+};
 import {
     Server,
     Globe,
@@ -179,32 +191,22 @@ const AgentDashboard = ({ agent, isDark }) => {
                             icon={Terminal}
                             theme={theme}
                         >
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div className="space-y-4">
                                 {agent.skills.map((skill, index) => {
                                     const uniqueKey = `skill-${skill.id || 'no-id'}-${skill.name}-${index}`;
                                     return (
                                         <div
                                             key={uniqueKey}
-                                            className={`group relative p-4 rounded-lg border transition-all duration-200 ${theme.border} ${theme.skillCardHover}`}>
+                                            className={`group p-4 rounded-lg border transition-all duration-200 ${theme.border} ${theme.skillCardHover}`}>
                                             <div className="flex justify-between items-start mb-2">
                                                 <span className={`font-mono text-base font-semibold ${theme.textPrimary}`}>
                                                     {skill.name}
                                                 </span>
                                             </div>
-                                            <p className={`text-base ${theme.textSecondary} line-clamp-2 mb-3`}>
+                                            <p className={`text-sm break-words ${theme.textSecondary} mb-3`}>
                                                 {skill.description}
                                             </p>
-                                            <div className="absolute bottom-[calc(100%-10px)] left-1/2 -translate-x-1/2 invisible opacity-0 translate-y-1
-                                                group-hover:visible group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-200 ease-out z-30 w-full min-w-[200px] max-w-[280px]
-                                                pointer-events-none">
-                                                <div className={`relative px-3 py-2 rounded-lg shadow-xl border text-sm leading-relaxed
-                                                    ${isDark ? 'bg-zinc-800 text-slate-200 border-zinc-700' : 'bg-white text-slate-700 border-slate-200'}`}>
-                                                    {skill.description}
-                                                    <div className={`absolute -bottom-1 left-1/2 -translate-x-1/2 w-2 h-2 rotate-45 border-b border-r
-                                                        ${isDark ? 'bg-zinc-800 border-zinc-700' : 'bg-white border-slate-200'}`} />
-                                                </div>
-                                            </div>
-                                            <div className="flex flex-wrap gap-2 mt-auto">
+                                            <div className="flex flex-wrap gap-2">
                                                 {(skill.tags || []).map(tag => (
                                                     <span key={tag}
                                                         className={`text-[10px] px-1.5 py-0.5 rounded border ${theme.border} ${theme.textSecondary}`}>
@@ -214,13 +216,33 @@ const AgentDashboard = ({ agent, isDark }) => {
                                             </div>
                                             {(skill.examples || []).length > 0 && (
                                                 <details className="mt-3">
-                                                    <summary className={`text-xs cursor-pointer ${theme.textSecondary} hover:${theme.textPrimary}`}>
-                                                        {`示例 (${skill.examples.length})`}
+                                                    <summary className={`text-xs cursor-pointer ${theme.textSecondary} hover:${theme.textPrimary} select-none`}>
+                                                        示例 ({skill.examples.length})
                                                     </summary>
-                                                    <div className={`mt-2 space-y-2 max-h-60 overflow-y-auto text-xs leading-relaxed font-mono whitespace-pre-wrap p-2 rounded ${isDark ? 'bg-zinc-900 text-slate-300' : 'bg-slate-50 text-slate-600'}`}>
+                                                    <div className="mt-3 space-y-4 max-h-96 overflow-y-auto">
                                                         {skill.examples.map((example, i) => (
-                                                            <div key={i} className="pb-2 border-b last:border-b-0 last:pb-0 border-slate-200 dark:border-zinc-700">
-                                                                {example}
+                                                            <div key={i} className={`text-sm leading-relaxed p-3 rounded border ${theme.border} ${isDark ? 'bg-zinc-900/50' : 'bg-slate-50'}`}>
+                                                                <ReactMarkdown
+                                                                    remarkPlugins={[remarkGfm]}
+                                                                    components={{
+                                                                        h1: ({children}) => <h3 className="text-base font-bold mt-0 mb-2">{children}</h3>,
+                                                                        h2: ({children}) => <h3 className="text-base font-bold mt-0 mb-2">{children}</h3>,
+                                                                        h3: ({children}) => <h3 className="text-sm font-bold mt-3 mb-1">{children}</h3>,
+                                                                        p: ({children}) => <p className="my-1">{children}</p>,
+                                                                        ul: ({children}) => <ul className="list-disc pl-5 my-1 space-y-0.5">{children}</ul>,
+                                                                        ol: ({children}) => <ol className="list-decimal pl-5 my-1 space-y-0.5">{children}</ol>,
+                                                                        code: ({children, className}) => {
+                                                                            const isInline = !className;
+                                                                            return isInline
+                                                                                ? <code className="px-1 py-0.5 rounded text-xs font-mono bg-zinc-200 dark:bg-zinc-700">{children}</code>
+                                                                                : <code className={className}>{children}</code>;
+                                                                        },
+                                                                        pre: ({children}) => <pre className="p-3 rounded text-xs font-mono overflow-x-auto bg-zinc-200 dark:bg-zinc-800 my-2">{children}</pre>,
+                                                                        blockquote: ({children}) => <blockquote className="pl-3 border-l-4 border-blue-400 italic my-2 text-zinc-500 dark:text-zinc-400">{children}</blockquote>,
+                                                                    }}
+                                                                >
+                                                                    {unescapeJsonString(example)}
+                                                                </ReactMarkdown>
                                                             </div>
                                                         ))}
                                                     </div>
@@ -246,163 +268,170 @@ const AgentDashboard = ({ agent, isDark }) => {
                 </div>
 
                 {advancedExpanded && (
-                    <div className="animate-in fade-in duration-300 pl-1">
-                        <div className="grid grid-cols-1 md:grid-cols-12 gap-6">
-                            <div className="col-span-1 md:col-span-8 space-y-6">
-                                {agent.supportedInterfaces && agent.supportedInterfaces.length > 0 && (
-                                    <InfoCard
-                                        title={`${t('agent_profile.supported_interfaces')} (${agent.supportedInterfaces.length})`}
-                                        icon={Server}
-                                        theme={theme}
-                                    >
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                            {agent.supportedInterfaces.map((iface, index) => (
-                                                <div
-                                                    key={`interface-${index}`}
-                                                    className={`p-4 rounded-lg border transition-all duration-200 ${theme.border} ${theme.skillCardHover}`}>
-                                                    <div className="flex justify-between items-start mb-2">
-                                                        <span className={`font-mono text-base font-semibold ${theme.textPrimary}`}>
-                                                            {iface.protocolBinding}
-                                                        </span>
-                                                        <span className={`text-[10px] px-1 border rounded ${theme.border} ${theme.textSecondary} opacity-60`}>
-                                                            v{iface.protocolVersion}
-                                                        </span>
-                                                    </div>
-                                                    <div className={`text-sm ${theme.textSecondary} truncate font-mono`} title={iface.url}>
-                                                        {iface.url}
-                                                    </div>
-                                                </div>
-                                            ))}
-                                        </div>
-                                    </InfoCard>
-                                )}
-                            </div>
-                            <div className="col-span-1 md:col-span-4 space-y-6">
-                                <InfoCard
-                                    title={t('agent_profile.capabilities')}
-                                    icon={Cpu}
-                                    theme={theme}
-                                >
-                                    <div className="grid grid-cols-1 gap-3">
-                                        <CapabilityToggle
-                                            label={t('agent_profile.streaming')}
-                                            active={agent.capabilities.streaming}
-                                            icon={Activity}
-                                            theme={theme}
-                                        />
-                                        <CapabilityToggle
-                                            label={t('agent_profile.stateTransitionHistory')}
-                                            active={agent.capabilities.stateTransitionHistory}
-                                            icon={Layers}
-                                            theme={theme}
-                                        />
-                                        <CapabilityToggle
-                                            label={t('agent_profile.pushNotifications')}
-                                            active={agent.capabilities.pushNotifications}
-                                            icon={Zap}
-                                            theme={theme}
-                                        />
-                                    </div>
-                                </InfoCard>
-                                {agent.securitySchemes && Object.keys(agent.securitySchemes).length > 0 && (
-                                    <InfoCard
-                                        title={t('agent_profile.security')}
-                                        icon={Shield}
-                                        theme={theme}
-                                    >
-                                        <div className="space-y-2">
-                                            {Object.entries(agent.securitySchemes).map(([name, scheme]) => (
-                                                <div key={name}
-                                                    className={`flex items-center justify-between p-2 rounded border ${theme.border}`}>
-                                                    <div className="flex items-center gap-2">
-                                                        <Shield className="w-4 h-4 text-amber-500" />
-                                                        <span className={`text-sm font-mono font-medium ${theme.textPrimary}`}>{name}</span>
-                                                    </div>
-                                                    <span className={`text-xs px-2 py-0.5 rounded ${isDark ? 'bg-zinc-800 text-zinc-400' : 'bg-zinc-100 text-zinc-600'}`}>
-                                                        {scheme.httpAuthSecurityScheme?.scheme || scheme.scheme || 'N/A'}
-                                                    </span>
-                                                </div>
-                                            ))}
-                                        </div>
-                                    </InfoCard>
-                                )}
-                                {agent.capabilities?.extensions && agent.capabilities.extensions.length > 0 && (
-                                    <InfoCard
-                                        title={t('agent_profile.extensions')}
-                                        icon={Puzzle}
-                                        theme={theme}
-                                    >
-                                        <div className="space-y-2">
-                                            {agent.capabilities.extensions.map((ext, idx) => (
-                                                <div key={idx}
-                                                    className={`p-2 rounded border ${theme.border}`}>
-                                                    <div className={`text-xs font-mono truncate ${theme.textSecondary}`}
-                                                        title={ext.uri}>
-                                                        {ext.uri}
-                                                    </div>
-                                                    {ext.required !== undefined && (
-                                                        <span className={`text-[10px] ${ext.required ? 'text-amber-500' : 'text-zinc-500'}`}>
-                                                            {ext.required ? 'required' : 'optional'}
-                                                        </span>
-                                                    )}
-                                                </div>
-                                            ))}
-                                        </div>
-                                    </InfoCard>
-                                )}
-                                <InfoCard
-                                    title={t('agent_profile.configuration')}
-                                    icon={Settings}
-                                    theme={theme}
-                                >
-                                    <div className="space-y-1">
-                                        <StatusRow
-                                            label={t('agent_profile.protocolVersion')}
-                                            value={`v${agent.version}`}
-                                            theme={theme}
-                                        />
-                                        <div className="pt-4">
-                                            <span className={`text-xs uppercase font-semibold tracking-wider ${theme.label}`}>
-                                                {t('agent_profile.defaultInputModes')}
-                                            </span>
-                                            <div className="flex flex-wrap gap-2 mt-2 mb-4">
-                                                {agent.defaultInputModes.map(m => (
-                                                    <span key={m}
-                                                          className={`px-2 py-1 text-xs rounded border ${theme.border} ${theme.textSecondary} bg-opacity-50`}>
-                                                        {m}
-                                                    </span>
-                                                ))}
+                    <div className="animate-in fade-in duration-300 pl-1 space-y-6">
+                        {agent.supportedInterfaces && agent.supportedInterfaces.length > 0 && (
+                            <InfoCard
+                                title={`${t('agent_profile.supported_interfaces')} (${agent.supportedInterfaces.length})`}
+                                icon={Server}
+                                theme={theme}
+                            >
+                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                                    {agent.supportedInterfaces.map((iface, index) => (
+                                        <div
+                                            key={`interface-${index}`}
+                                            className={`p-4 rounded-lg border transition-all duration-200 ${theme.border} ${theme.skillCardHover}`}>
+                                            <div className="flex justify-between items-start mb-2">
+                                                <span className={`font-mono text-base font-semibold ${theme.textPrimary}`}>
+                                                    {iface.protocolBinding}
+                                                </span>
+                                                <span className={`text-[10px] px-1 border rounded ${theme.border} ${theme.textSecondary} opacity-60`}>
+                                                    v{iface.protocolVersion}
+                                                </span>
                                             </div>
+                                            <div className={`text-sm ${theme.textSecondary} truncate font-mono`} title={iface.url}>
+                                                {iface.url}
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </InfoCard>
+                        )}
 
-                                            <span className={`text-xs uppercase font-semibold tracking-wider ${theme.label}`}>
-                                                {t('agent_profile.defaultOutputModes')}
-                                            </span>
-                                            <div className="flex flex-wrap gap-2 mt-2">
-                                                {agent.defaultOutputModes.map(m => (
-                                                    <span key={m}
-                                                          className={`px-2 py-1 text-xs rounded border ${theme.border} ${theme.textSecondary} bg-opacity-50`}>
-                                                        {m}
+                        {agent.capabilities?.extensions && agent.capabilities.extensions.length > 0 && (
+                            <InfoCard
+                                title={`${t('agent_profile.extensions')} (${agent.capabilities.extensions.length})`}
+                                icon={Puzzle}
+                                theme={theme}
+                            >
+                                <div className="space-y-3">
+                                    {agent.capabilities.extensions.map((ext, idx) => (
+                                        <div key={idx}
+                                            className={`p-3 rounded-lg border ${theme.border}`}>
+                                            <div className={`text-sm font-mono break-all ${theme.textPrimary}`}
+                                                title={ext.uri}>
+                                                {ext.uri}
+                                            </div>
+                                            <div className="flex items-center gap-2 mt-2">
+                                                {ext.required !== undefined && (
+                                                    <span className={`text-[10px] px-1.5 py-0.5 rounded ${ext.required ? 'bg-amber-500/10 text-amber-600 border border-amber-500/30' : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-500 border border-zinc-200 dark:border-zinc-700'}`}>
+                                                        {ext.required ? 'required' : 'optional'}
                                                     </span>
-                                                ))}
+                                                )}
+                                                {ext.description && (
+                                                    <span className={`text-xs ${theme.textSecondary}`}>
+                                                        {ext.description}
+                                                    </span>
+                                                )}
                                             </div>
                                         </div>
+                                    ))}
+                                </div>
+                            </InfoCard>
+                        )}
+
+                        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                            <InfoCard
+                                title={t('agent_profile.capabilities')}
+                                icon={Cpu}
+                                theme={theme}
+                            >
+                                <div className="grid grid-cols-1 gap-3">
+                                    <CapabilityToggle
+                                        label={t('agent_profile.streaming')}
+                                        active={agent.capabilities.streaming}
+                                        icon={Activity}
+                                        theme={theme}
+                                    />
+                                    <CapabilityToggle
+                                        label={t('agent_profile.stateTransitionHistory')}
+                                        active={agent.capabilities.stateTransitionHistory}
+                                        icon={Layers}
+                                        theme={theme}
+                                    />
+                                    <CapabilityToggle
+                                        label={t('agent_profile.pushNotifications')}
+                                        active={agent.capabilities.pushNotifications}
+                                        icon={Zap}
+                                        theme={theme}
+                                    />
+                                </div>
+                            </InfoCard>
+
+                            {agent.securitySchemes && Object.keys(agent.securitySchemes).length > 0 && (
+                                <InfoCard
+                                    title={t('agent_profile.security')}
+                                    icon={Shield}
+                                    theme={theme}
+                                >
+                                    <div className="space-y-2">
+                                        {Object.entries(agent.securitySchemes).map(([name, scheme]) => (
+                                            <div key={name}
+                                                className={`flex items-center justify-between p-2 rounded border ${theme.border}`}>
+                                                <div className="flex items-center gap-2">
+                                                    <Shield className="w-4 h-4 text-amber-500" />
+                                                    <span className={`text-sm font-mono font-medium ${theme.textPrimary}`}>{name}</span>
+                                                </div>
+                                                <span className={`text-xs px-2 py-0.5 rounded ${isDark ? 'bg-zinc-800 text-zinc-400' : 'bg-zinc-100 text-zinc-600'}`}>
+                                                    {scheme.httpAuthSecurityScheme?.scheme || scheme.scheme || 'N/A'}
+                                                </span>
+                                            </div>
+                                        ))}
                                     </div>
-                                    {agent.documentationUrl && (
-                                        <a
-                                            href={agent.documentationUrl}
-                                            target="_blank"
-                                            rel="noreferrer"
-                                            className={`mt-6 flex items-center justify-center gap-2 w-full py-2 rounded-lg text-sm font-medium transition-colors ${isDark
-                                                ? 'bg-blue-600/20 hover:bg-blue-600/30 text-blue-400'
-                                                : 'bg-blue-50 hover:bg-blue-100 text-blue-700'
-                                            }`}
-                                        >
-                                            <Globe className="w-4 h-4" />
-                                            {t('agent_profile.documentationUrl')}
-                                        </a>
-                                    )}
                                 </InfoCard>
-                            </div>
+                            )}
+
+                            <InfoCard
+                                title={t('agent_profile.configuration')}
+                                icon={Settings}
+                                theme={theme}
+                            >
+                                <div className="space-y-1">
+                                    <StatusRow
+                                        label={t('agent_profile.protocolVersion')}
+                                        value={`v${agent.version}`}
+                                        theme={theme}
+                                    />
+                                    <div className="pt-4">
+                                        <span className={`text-xs uppercase font-semibold tracking-wider ${theme.label}`}>
+                                            {t('agent_profile.defaultInputModes')}
+                                        </span>
+                                        <div className="flex flex-wrap gap-2 mt-2 mb-4">
+                                            {agent.defaultInputModes.map(m => (
+                                                <span key={m}
+                                                      className={`px-2 py-1 text-xs rounded border ${theme.border} ${theme.textSecondary} bg-opacity-50`}>
+                                                    {m}
+                                                </span>
+                                            ))}
+                                        </div>
+
+                                        <span className={`text-xs uppercase font-semibold tracking-wider ${theme.label}`}>
+                                            {t('agent_profile.defaultOutputModes')}
+                                        </span>
+                                        <div className="flex flex-wrap gap-2 mt-2">
+                                            {agent.defaultOutputModes.map(m => (
+                                                <span key={m}
+                                                      className={`px-2 py-1 text-xs rounded border ${theme.border} ${theme.textSecondary} bg-opacity-50`}>
+                                                    {m}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    </div>
+                                </div>
+                                {agent.documentationUrl && (
+                                    <a
+                                        href={agent.documentationUrl}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className={`mt-6 flex items-center justify-center gap-2 w-full py-2 rounded-lg text-sm font-medium transition-colors ${isDark
+                                            ? 'bg-blue-600/20 hover:bg-blue-600/30 text-blue-400'
+                                            : 'bg-blue-50 hover:bg-blue-100 text-blue-700'
+                                        }`}
+                                    >
+                                        <Globe className="w-4 h-4" />
+                                        {t('agent_profile.documentationUrl')}
+                                    </a>
+                                )}
+                            </InfoCard>
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
## Summary

### Extension Protocol Fixes
- Use official 2a-sdk get_requested_extensions() in ExtensionInterceptor instead of manual string manipulation
- Add NEGOTIATION-T and DATA-NEGOTIATION-T extension URIs to all 10 sample AgentCards
- Standardize all extension URIs to https://github.com/a2aproject/telecommunication/extensions/ base (matching the A2A-T SDK constants)
- Use A2A-T extension URI keys (NEGOTIATION_TEXT_KEY, NEGOTIATION_CONTEXT_KEY) in message/task metadata instead of plain 
egotiationContext/
egotiationText keys

### UI Layout Fixes
- Restructure AgentCard advanced properties section: each sub-card (supported interfaces, extensions, capabilities/security/config) occupies its own full-width row
- Expand extension support card to full width, change URI display from 	runcate to reak-all for readability
- Use eact-markdown + emark-gfm to render skill examples in markdown format
- Add unescapeJsonString() to handle JSON-escaped \\n sequences in examples

### Files Changed
- common/auth/extension_interceptor.py
- common/negotiation_utils.py
- orchestrate/runtime/exec_engine.py
- samples/agents/negotiation_base_agent.py
- samples/agentcard/*.json (10 files)
- workflow-designer/src/components/registry_center/agentcard_visualization/index.jsx
- workflow-designer/package.json
- workflow-designer/package-lock.json

Closes #18