### PR TITLE
feat: add TASK-T prompt stubbing for dev/testing and update agent credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ log/
 workflow-designer/dist/
 workflow-designer/stats.html
 data/
+etc/conf/task_prompt_stubs.json

--- a/etc/conf/agent_credentials.json
+++ b/etc/conf/agent_credentials.json
@@ -1,2 +1,32 @@
 {
+  "SPN Domain Agent": {
+    "bearerAuth": {
+      "login_url": "https://127.0.0.1:26335/rest/plat/smapp/v1/oauth/token",
+      "method": "PUT",
+      "request_fields": {
+        "grantType": "password",
+        "userName": "<YOUR_USERNAME>",
+        "value": "<YOUR_PASSWORD>",
+        "ipaddr": "*"
+      },
+      "token_field": "accessSession"
+    }
+  },
+  "Workbench Platform Agent": {
+    "bearerAuth": {
+      "login_url": "http://127.0.0.1:26336/bgw/cswg-service/oauth/token",
+      "method": "POST",
+      "content_type": "application/x-www-form-urlencoded",
+      "request_fields": {
+        "grant_type": "password",
+        "username": "<YOUR_USERNAME>",
+        "password": "<YOUR_PASSWORD_ENCRYPTED>",
+        "client_id": "<YOUR_CLIENT_ID>",
+        "mode": "plain"
+      },
+      "token_field": "data.access_token",
+      "auth_header": "fmind-auth",
+      "accept_header": "*/*"
+    }
+  }
 }

--- a/etc/conf/agent_credentials.json.template
+++ b/etc/conf/agent_credentials.json.template
@@ -25,7 +25,8 @@
         "mode": "plain"
       },
       "token_field": "data.access_token",
-      "auth_header": "fmind-auth"
+      "auth_header": "fmind-auth",
+      "accept_header": "*/*"
     }
   }
 }

--- a/etc/conf/task_prompt_stubs.json.example
+++ b/etc/conf/task_prompt_stubs.json.example
@@ -1,0 +1,7 @@
+{
+    "_comment": "TASK-T prompt stub configuration for development/testing.",
+    "_usage": "Copy to task_prompt_stubs.json and fill agent stubs. Each key is an agent name. Value can be: (a) a plain string → injected as metadata[TASK-T-URI], or (b) a dict → injected as metadata[key] directly. Agents not listed use the normal A2A-T SDK generation pipeline.",
+    "stubs": {
+        "SPN Domain Agent": "## Task Type\nSPN专线投诉诊断\n## Task Description\n要求：提供任务的整体概述，基于<Task Object>、<Task Context>进行投诉场景的网络侧故障根因诊断。\n## Task Target\n诊断并返回网络侧的故障根因\n## Expected Output\n1. 诊断结果类型\n2. 诊断结果详细信息\n3. 修复建议"
+    }
+}

--- a/orchestrate/runtime/exec_engine.py
+++ b/orchestrate/runtime/exec_engine.py
@@ -125,7 +125,9 @@ class DynamicWorkflowEngine:
         self._httpx_client: Optional[httpx.AsyncClient] = None
         self.execution_context_id = ""
         self._auth_interceptors: Dict[str, List[Any]] = {}
+        self._task_stubs: Dict[str, str] = {}
         self._setup_agent_auth()
+        self._load_task_stubs()
 
         if _A2AT_AVAILABLE:
             from common.a2at_config import get_a2at_env_path, update_a2at_language
@@ -170,6 +172,22 @@ class DynamicWorkflowEngine:
                     logger.info(f"Agent '{card.name}' configured with ExtensionInterceptor: {ext_uris}")
             if interceptors:
                 self._auth_interceptors[card.name] = interceptors
+
+    def _load_task_stubs(self):
+        stub_path = Path(__file__).resolve().parent.parent.parent / "etc" / "conf" / "task_prompt_stubs.json"
+        if not stub_path.is_file():
+            return
+        try:
+            data = json.loads(stub_path.read_text(encoding='utf-8'))
+        except Exception:
+            return
+        stubs = data.get("stubs", {}) if isinstance(data, dict) else {}
+        if stubs:
+            self._task_stubs = {
+                k: v for k, v in stubs.items()
+                if (isinstance(v, str) and v.strip()) or (isinstance(v, dict) and v)
+            }
+            logger.info(f"[A2AT] Loaded {len(self._task_stubs)} task prompt stub(s): {list(self._task_stubs.keys())}")
 
     def set_push_callback(self, callback: Callable[[str, Dict[str, Any]], None]):
         self.push_callback = callback
@@ -377,16 +395,28 @@ class DynamicWorkflowEngine:
         except ImportError:
             pass
 
-        if self.a2at_client and task_t_uri and not skip_prompt_gen:
-            try:
-                prompt_result = self.a2at_client.generate_task_prompt(task)
-                if prompt_result.success and prompt_result.prompt_text:
-                    task_t_metadata = prompt_result.prompt_text
-                    logger.info(f"[A2AT] Generated TASK-T prompt for agent '{agent_name}', will set in metadata")
+        if task_t_uri and not skip_prompt_gen:
+            stub_text = self._task_stubs.get(agent_name)
+            if stub_text:
+                if isinstance(stub_text, dict):
+                    task_t_metadata = stub_text.get(task_t_uri)
+                    for uri, val in stub_text.items():
+                        if uri != task_t_uri and isinstance(val, str):
+                            logger.info(f"[A2AT] Also stub metadata key '{uri}' for agent '{agent_name}'")
                 else:
-                    logger.warning(f"[A2AT] Task prompt generation failed, using original task")
-            except Exception as e:
-                logger.warning(f"[A2AT] Failed to generate task prompt: {e}")
+                    task_t_metadata = stub_text
+                if task_t_metadata:
+                    logger.info(f"[A2AT] Using stub task prompt for agent '{agent_name}'")
+            elif self.a2at_client:
+                try:
+                    prompt_result = self.a2at_client.generate_task_prompt(task)
+                    if prompt_result.success and prompt_result.prompt_text:
+                        task_t_metadata = prompt_result.prompt_text
+                        logger.info(f"[A2AT] Generated TASK-T prompt for agent '{agent_name}', will set in metadata")
+                    else:
+                        logger.warning(f"[A2AT] Task prompt generation failed, using original task")
+                except Exception as e:
+                    logger.warning(f"[A2AT] Failed to generate task prompt: {e}")
 
         try:
             client = httpx_client or self._get_httpx_client()
@@ -417,6 +447,10 @@ class DynamicWorkflowEngine:
                 from google.protobuf.struct_pb2 import Struct
                 meta = Struct()
                 meta.update({task_t_uri: task_t_metadata})
+                if isinstance(self._task_stubs.get(agent_name), dict):
+                    for uri, val in self._task_stubs[agent_name].items():
+                        if uri != task_t_uri and isinstance(val, str):
+                            meta.update({uri: val})
                 request_msg.metadata.CopyFrom(meta)
                 logger.info(f"[A2AT] Set TASK-T metadata on message for agent '{agent_name}'")
             send_req = SendMessageRequest(message=request_msg)


### PR DESCRIPTION
## Summary

### TASK-T Prompt Stubbing
- Add etc/conf/task_prompt_stubs.json config (gitignored) with .example template
- Engine loads per-agent stubs in _load_task_stubs() and injects directly into message.metadata, bypassing LLM
- Supports plain string (auto-mapped to TASK-T URI) and dict (exact metadata key-value) formats
- Does not require 2a-t-sdk installed when using stubs

### Agent Credentials
- Add SPN Domain Agent OAuth2 bearerAuth credentials
- Add Workbench Platform Agent OAuth2 credentials with mind-auth custom header and ccept_header: */*

Closes #21