### PR TITLE
refactor: migrate extension URIs from github.com to projects.tmforum.org

### DIFF
--- a/common/negotiation_utils.py
+++ b/common/negotiation_utils.py
@@ -18,13 +18,13 @@
 from typing import Dict, Any, Optional
 from loguru import logger
 
+from a2a_t.negotiation.common.constants import (
+    NEGOTIATION_TEXT_KEY,
+    NEGOTIATION_CONTEXT_KEY,
+    TASK_PROMPT_KEY,
+)
 from a2a_t.negotiation.common.enums import NegotiationType, NegotiationStatus
 from a2a_t.negotiation.common.models import NegotiationContext
-
-
-NEGOTIATION_TEXT_KEY = "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T"
-NEGOTIATION_CONTEXT_KEY = "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1"
-TASK_PROMPT_KEY = "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1"
 
 NEGOTIATION_RESOLUTION_MARKER = "[NEGOTIATION_RESOLUTION]"
 NEGOTIATION_REQUEST_MARKER = "[NEGOTIATION_REQUEST]"

--- a/samples/agentcard/assurance_agent.json
+++ b/samples/agentcard/assurance_agent.json
@@ -33,17 +33,17 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/energy_saving_intent_agent.json
+++ b/samples/agentcard/energy_saving_intent_agent.json
@@ -55,17 +55,17 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/live_streaming_agent.json
+++ b/samples/agentcard/live_streaming_agent.json
@@ -33,17 +33,17 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/ran_agent.json
+++ b/samples/agentcard/ran_agent.json
@@ -42,17 +42,17 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/ran_energy_saving_agent.json
+++ b/samples/agentcard/ran_energy_saving_agent.json
@@ -45,17 +45,17 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/spn_agent_card.json
+++ b/samples/agentcard/spn_agent_card.json
@@ -15,15 +15,15 @@
         {
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false,
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1"
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1"
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/spn_fault_handling_agent_city1_omc.json
+++ b/samples/agentcard/spn_fault_handling_agent_city1_omc.json
@@ -24,17 +24,17 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/spn_fault_handling_agent_city2_omc.json
+++ b/samples/agentcard/spn_fault_handling_agent_city2_omc.json
@@ -24,17 +24,17 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/transport_workbench_agent.json
+++ b/samples/agentcard/transport_workbench_agent.json
@@ -33,17 +33,17 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/uncertainty_simulation_agent.json
+++ b/samples/agentcard/uncertainty_simulation_agent.json
@@ -25,17 +25,17 @@
       "streaming": false,
       "extensions": [
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
           "description": "Extension of structured prompt TASK-T requests.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
           "description": "Extension for A2A-T negotiation text exchange.",
           "required": false
         },
         {
-          "uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+          "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
           "description": "Extension for A2A-T negotiation context data.",
           "required": false
         }

--- a/samples/agentcard/workbench_platform_agent_card.json
+++ b/samples/agentcard/workbench_platform_agent_card.json
@@ -12,17 +12,17 @@
 			"extendedAgentCard": false,
 			"extensions": [
 				{
-					"uri": "https://github.com/a2aproject/telecommunication/extensions/Task-T/v1",
+					"uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Task-T/v1",
 					"description": "Extension of structured prompt TASK-T requests.",
 					"required": false
 				},
 				{
-					"uri": "https://github.com/a2aproject/telecommunication/extensions/NEGOTIATION-T",
+					"uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/NEGOTIATION-T",
 					"description": "Extension for A2A-T negotiation text exchange.",
 					"required": false
 				},
 				{
-					"uri": "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
+					"uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1",
 					"description": "Extension for A2A-T negotiation context data.",
 					"required": false
 				}

--- a/test/test_exec_engine.py
+++ b/test/test_exec_engine.py
@@ -1279,7 +1279,7 @@ class TestNegotiationFlow:
         task.status = status
         task.metadata = {
             "negotiationConcern": "I need more information about the target",
-            "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1": {
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1": {
                 "negotiationType": "fulfillment",
                 "negotiationId": "neg-001",
                 "role": "client",
@@ -1325,7 +1325,7 @@ class TestNegotiationFlow:
             "message": "Acknowledged",
         }
         mock.continue_negotiation.return_value = {
-            "https://github.com/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1": {
+            "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1": {
                 "negotiationType": "fulfillment",
                 "negotiationId": "neg-001",
                 "round": 1,


### PR DESCRIPTION
Closes #25

## Summary

- Replace hardcoded extension URI definitions in 
egotiation_utils.py with imports from 2a_t.negotiation.common.constants (aligns with SDK upstream PR #22)
- Update all 11 agent card sample JSONs: github.com ? projects.tmforum.org`n- Update 	est_exec_engine.py references accordingly

## Changes

| File | Change |
|------|--------|
| common/negotiation_utils.py | Remove hardcoded URI strings, import from SDK constants |
| samples/agentcard/*.json (11 files) | Update extension URIs to tmforum |
| 	est/test_exec_engine.py | Update test URIs |