### PR TITLE
fix: register deepseek as a2a-t-sdk LLM provider on startup

### DIFF
--- a/common/a2at_config.py
+++ b/common/a2at_config.py
@@ -23,6 +23,11 @@ from urllib.parse import urlparse
 
 from loguru import logger
 
+from a2a_t.llm.factory import LLMClientFactory
+from a2a_t.llm.providers.openai import OpenAIClient
+
+LLMClientFactory.register("deepseek", OpenAIClient)
+
 LANG_MAP = {"en": "en-US", "zh": "zh-CN"}
 
 


### PR DESCRIPTION
Closes #27