### PR TITLE
fix: Task-T prompt generation and negotiation forwarding improvements

### DIFF
--- a/common/a2at_config.py
+++ b/common/a2at_config.py
@@ -42,9 +42,23 @@ def get_a2at_env_path(env_path: Path = None) -> Path:
     return _default_env_path()
 
 
+def _get_available_languages() -> set[str]:
+    from a2a_t.config.models import _default_prompt_resource_root_dir
+    root = Path(_default_prompt_resource_root_dir())
+    scenarios_dir = root / "scenarios"
+    if not scenarios_dir.is_dir():
+        return set()
+    return {d.name for d in scenarios_dir.iterdir() if d.is_dir() and (d / "scenarios.json").exists()}
+
+
 def update_a2at_language(language: str, env_path: Path = None) -> None:
     path = get_a2at_env_path(env_path)
     lang_code = LANG_MAP.get(language, language)
+    available = _get_available_languages()
+    if available and lang_code not in available:
+        fallback = "zh-CN" if "zh-CN" in available else next(iter(available))
+        logger.info(f"Language '{lang_code}' has no prompt resources, falling back to '{fallback}'")
+        lang_code = fallback
     content = path.read_text(encoding='utf-8')
     updated = re.sub(r'^(A2AT_LANGUAGE=).*$', rf'\1{lang_code}', content, flags=re.MULTILINE)
     path.write_text(updated, encoding='utf-8')

--- a/orchestrate/runtime/exec_engine.py
+++ b/orchestrate/runtime/exec_engine.py
@@ -599,13 +599,18 @@ class DynamicWorkflowEngine:
 
         logger.info(f"Processing negotiation from agent '{agent_name}': {negotiation_text[:150]}...")
 
+        # Step 1: mechanically forward to predecessor agents.
+        # Only ask direct DAG predecessors; never cross-layer.
+        predecessor_data = await self._forward_to_predecessors(agent_name, negotiation_text)
+
         if not context_data:
-            logger.info(f"No negotiation context in response, generating simple clarification")
-            clarification = await self._generate_negotiation_clarification(
+            # Simple negotiation (no A2A-T protocol context).
+            clarification = await self._build_negotiation_clarification(
                 agent_name=agent_name,
                 original_task=clean_original,
                 negotiation_text=negotiation_text,
                 receive_message="",
+                predecessor_data=predecessor_data,
             )
             if clarification:
                 resolved = build_negotiation_resolution_task(clean_original, clarification)
@@ -630,6 +635,7 @@ class DynamicWorkflowEngine:
             })
             return None
 
+        # Step 2: A2A-T protocol negotiation flow.
         try:
             receive_result = self.a2at_client.receive_negotiation(
                 message=negotiation_text,
@@ -656,11 +662,12 @@ class DynamicWorkflowEngine:
             })
             return None
 
-        clarification = await self._generate_negotiation_clarification(
+        clarification = await self._build_negotiation_clarification(
             agent_name=agent_name,
             original_task=clean_original,
             negotiation_text=negotiation_text,
             receive_message=receive_result.get("message", ""),
+            predecessor_data=predecessor_data,
         )
 
         if not clarification:
@@ -674,7 +681,6 @@ class DynamicWorkflowEngine:
                 }, ensure_ascii=False),
             })
             return None
-
         from a2a_t.negotiation.common.enums import NegotiationStatus
         from a2a_t.negotiation.common.models import ContinueNegotiationInput, NegotiationContext
 
@@ -717,6 +723,95 @@ class DynamicWorkflowEngine:
             }, ensure_ascii=False),
         })
         return resolved_task
+
+    async def _build_negotiation_clarification(
+        self,
+        agent_name: str,
+        original_task: str,
+        negotiation_text: str,
+        receive_message: str,
+        predecessor_data: Optional[str],
+    ) -> Optional[str]:
+        """Build the response used to resolve a negotiation request."""
+        if predecessor_data:
+            return predecessor_data
+        return await self._generate_negotiation_clarification(
+            agent_name=agent_name,
+            original_task=original_task,
+            negotiation_text=negotiation_text,
+            receive_message=receive_message,
+        )
+
+    async def _forward_to_predecessors(
+        self,
+        agent_name: str,
+        negotiation_text: str,
+    ) -> Optional[str]:
+        """Mechanically forward negotiation request to direct DAG predecessor agents.
+
+        Only queries *direct* predecessors of the current step; never cross-layer.
+        Uses raw agent call (no negotiation loop) to avoid infinite recursion.
+        """
+        current_idx = self.current_step_idx
+        if current_idx is None or current_idx >= len(self.workflow.steps):
+            logger.warning(f"Cannot forward negotiation: no current step context")
+            return None
+
+        current_step = self.workflow.steps[current_idx]
+        predecessor_names = self._get_step_predecessors(current_step.name)
+        if not predecessor_names:
+            logger.info(f"Step '{current_step.name}' has no predecessor steps, cannot forward")
+            return None
+
+        logger.info(
+            f"Forwarding negotiation request from '{agent_name}' "
+            f"(step '{current_step.name}') to predecessors: {predecessor_names}"
+        )
+
+        collected = {}
+        for pred_name in predecessor_names:
+            pred_step = self.workflow.steps[self._step_index.get(pred_name)]
+            if not pred_step or not pred_step.subtasks:
+                continue
+
+            # Include the original step output for context
+            prior_output = self.step_outputs.get(pred_name, {})
+            prior_summary = json.dumps(prior_output, ensure_ascii=False, default=str)[:2000]
+
+            for task in pred_step.subtasks:
+                pred_agent = task.agent
+                if not pred_agent:
+                    continue
+
+                forward_msg = (
+                    f"[Negotiation Request - Forwarded from Orchestrator]\n\n"
+                    f"Agent '{agent_name}' is processing a follow-up task "
+                    f"and indicates it needs additional data or clarification.\n\n"
+                    f"The original output you provided for step '{pred_name}':\n"
+                    f"---\n{prior_summary}\n---\n\n"
+                    f"The request from '{agent_name}':\n"
+                    f"---\n{negotiation_text}\n---\n\n"
+                    f"As the predecessor agent, please provide supplemental data "
+                    f"or clarification to help resolve this."
+                )
+
+                logger.info(f"Forwarding to predecessor '{pred_agent}' (step '{pred_name}')")
+                try:
+                    response, _, _ = await self._send_message_internal(pred_agent, forward_msg)
+                    if response:
+                        collected[pred_agent] = response
+                        logger.info(f"Got response from '{pred_agent}' ({len(response)} chars)")
+                    else:
+                        logger.warning(f"Empty response from '{pred_agent}'")
+                except Exception as e:
+                    logger.warning(f"Failed to contact predecessor '{pred_agent}': {e}")
+
+        if not collected:
+            logger.warning(f"No data collected from any predecessor agent")
+            return None
+
+        parts = [f"[Response from {a}]:\n{d}" for a, d in collected.items()]
+        return "\n\n".join(parts)
 
     async def _generate_negotiation_clarification(
         self,

--- a/orchestrate/runtime/exec_engine.py
+++ b/orchestrate/runtime/exec_engine.py
@@ -417,7 +417,14 @@ class DynamicWorkflowEngine:
                         task_t_metadata = prompt_result.prompt_text
                         logger.info(f"[A2AT] Generated TASK-T prompt for agent '{agent_name}', will set in metadata")
                     else:
-                        logger.warning(f"[A2AT] Task prompt generation failed, using original task")
+                        failure = prompt_result.failure
+                        if failure:
+                            logger.warning(
+                                f"[A2AT] Task prompt generation failed: "
+                                f"code={failure.code}, stage={failure.stage}, message={failure.message}"
+                            )
+                        else:
+                            logger.warning(f"[A2AT] Task prompt generation failed, using original task")
                 except Exception as e:
                     logger.warning(f"[A2AT] Failed to generate task prompt: {e}")
 

--- a/test/test_exec_engine.py
+++ b/test/test_exec_engine.py
@@ -1445,6 +1445,58 @@ class TestNegotiationFlow:
                     f"Expected negotiation_failed in events, got: {event_types}"
 
     @pytest.mark.asyncio
+    async def test_negotiation_without_predecessors_uses_clarification_fallback(
+        self, mock_agent_card, mock_llm_client
+    ):
+        """A negotiation on an entry step should still use the clarification fallback."""
+        mock_a2at = self._make_mock_a2at()
+        psop = PSOP(
+            name="negotiation_entry_step",
+            steps=[
+                Step(
+                    name="step1",
+                    type=StepType.ALL_SUCCESS,
+                    subtasks=[Task(description="Task A", agent="test_agent", skill="skill_a")],
+                    next=None,
+                )
+            ],
+        )
+        with patch('orchestrate.runtime.exec_engine.get_llm_instance',
+                   return_value=mock_llm_client):
+            with self._mock_a2at_patch as MockA2AT:
+                MockA2AT.return_value = mock_a2at
+                engine = DynamicWorkflowEngine(
+                    psop=psop, agent_cards=[mock_agent_card],
+                    a2at_env_path=MagicMock()
+                )
+
+        engine.current_step_idx = 0
+        engine._generate_negotiation_clarification = AsyncMock(
+            return_value="Fallback clarification"
+        )
+
+        resolved = await engine._handle_agent_negotiation(
+            "test_agent",
+            "original task",
+            {
+                "negotiationConcern": "I need more information about the target",
+                "https://projects.tmforum.org/a2aproject/telecommunication/extensions/DATA-NEGOTIATION-T/v1": {
+                    "negotiationType": "fulfillment",
+                    "negotiationId": "neg-001",
+                    "role": "client",
+                    "round": "1",
+                    "status": "in-progress",
+                    "extra": {},
+                },
+            },
+        )
+
+        assert resolved is not None
+        assert "Fallback clarification" in resolved
+        engine._generate_negotiation_clarification.assert_awaited_once()
+        mock_a2at.continue_negotiation.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_agent_returns_completed_no_negotiation(
         self, mock_agent_card, mock_llm_client, mock_completed_task
     ):


### PR DESCRIPTION
Closes #33
Closes #35

## Commit 1: feat: forward negotiation requests to DAG predecessor agents before LLM fallback

- Add `_forward_to_predecessors`: mechanically forwards negotiation text to direct DAG predecessor agents (no cross-layer) to avoid infinite recursion
- Add `_build_negotiation_clarification`: prefers predecessor data when available, falls back to LLM-generated clarification otherwise
- Add test for entry-step negotiation using clarification fallback

## Commit 2: fix: fallback to available language when prompt resources missing, add Task-T failure details

- `a2at_config.py`: `update_a2at_language` inspects the SDK's packaged `scenarios/` directory and falls back to `zh-CN` when the requested language has no resources
- `exec_engine.py`: Task-T generation failures now log `code`, `stage`, and `message` from `PromptGenerationFailure`