### PR TITLE
feat(validation): add pre-save topology validator for PSOP workflows

### DIFF
--- a/orchestrate/validation/__init__.py
+++ b/orchestrate/validation/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright contributors to the OpenAN project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public validation package exports."""
+
+from orchestrate.validation.models import (
+    CheckResult,
+    CheckStatus,
+    SecurityLevel,
+    StepSecurity,
+    TopologyValidationInput,
+    TopologyValidationReport,
+    Verdict,
+)
+from orchestrate.validation.topology_validator import validate_topology
+
+__all__ = [
+    "CheckResult",
+    "CheckStatus",
+    "SecurityLevel",
+    "StepSecurity",
+    "TopologyValidationInput",
+    "TopologyValidationReport",
+    "Verdict",
+    "validate_topology",
+]

--- a/orchestrate/validation/hooks.py
+++ b/orchestrate/validation/hooks.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright contributors to the OpenAN project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration hook example: validate a PSOP before saving.
+
+This is a drop-in example for Orchestration Center workflow CRUD handlers.
+It is not imported automatically to avoid side effects; maintainers can wire
+it into `frontend_support_server.py` or the workflow router of choice.
+"""
+
+from fastapi import HTTPException, status
+from orchestrate.core.model.psop import PSOP
+from orchestrate.validation.models import (
+    SecurityLevel,
+    StepSecurity,
+    TopologyValidationInput,
+    Verdict,
+)
+from orchestrate.validation.topology_validator import validate_topology
+
+
+async def validate_before_save(
+    psop: PSOP,
+    step_security: dict[str, StepSecurity] | None = None,
+    agent_security: dict[str, SecurityLevel] | None = None,
+) -> None:
+    """Raise HTTPException if PSOP topology validation fails.
+
+    Call this function inside workflow create/update endpoints before
+    persisting the PSOP. Optional security metadata can be supplied from
+    agent registry tags or external governance configuration.
+    """
+    report = validate_topology(
+        TopologyValidationInput(
+            psop=psop,
+            step_security=step_security or {},
+            agent_security=agent_security or {},
+        )
+    )
+
+    if report.final_verdict == Verdict.REJECT:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "message": "Workflow topology validation failed",
+                "errors": report.errors,
+                "warnings": report.warnings,
+            },
+        )
+    # APPROVE_WITH_CONDITIONS is allowed but can be logged or escalated.
+    if report.final_verdict == Verdict.APPROVE_WITH_CONDITIONS:
+        # TODO: emit audit/escalation log
+        pass

--- a/orchestrate/validation/models.py
+++ b/orchestrate/validation/models.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright contributors to the OpenAN project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pydantic models for topology validation.
+
+Defines the input schema consumed by the topology validator and the
+structured report it produces. The validator is intentionally decoupled
+from persistence concerns so that it can be invoked before any PSOP is
+saved or executed.
+"""
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from orchestrate.core.model.psop import PSOP
+
+
+class SecurityLevel(str, Enum):
+    """Security tier inspired by the MAEA layered governance model.
+
+    The numeric order is intentional: lower values are higher-trust layers.
+    A step/task at L1 (strategic) must not receive upstream delegation from
+    L2/L3 unless an explicit break-glass escalation is recorded.
+    """
+
+    L1_STRATEGIC = "L1"
+    L2_FUNCTIONAL = "L2"
+    L3_EXTERNAL = "L3"
+
+
+class Verdict(str, Enum):
+    """Final validation verdict."""
+
+    APPROVE = "approve"
+    APPROVE_WITH_CONDITIONS = "approve_with_conditions"
+    REJECT = "reject"
+
+
+class CheckStatus(str, Enum):
+    """Status of an individual validation check."""
+
+    PASS = "pass"
+    WARN = "warn"
+    REJECT = "reject"
+
+
+class StepSecurity(BaseModel):
+    """Optional per-step security metadata.
+
+    If not provided, the validator falls back to agent-level metadata or
+    treats the step as L2_FUNCTIONAL.
+    """
+
+    step_name: str = Field(..., description="Step name as declared in PSOP.steps")
+    security_level: SecurityLevel = Field(SecurityLevel.L2_FUNCTIONAL, description="Security tier")
+    break_glass: bool = Field(False, description="Explicit escalation allowed for this step")
+
+
+class TopologyValidationInput(BaseModel):
+    """Input to the topology validator."""
+
+    psop: PSOP = Field(..., description="PSOP workflow to validate")
+    step_security: Optional[Dict[str, StepSecurity]] = Field(
+        default_factory=dict,
+        description="Optional step-level security metadata keyed by step name",
+    )
+    agent_security: Optional[Dict[str, SecurityLevel]] = Field(
+        default_factory=dict,
+        description="Optional agent-level security tier keyed by agent name",
+    )
+    max_blast_radius_depth: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Maximum depth for downstream blast-radius traversal",
+    )
+
+
+class CheckResult(BaseModel):
+    """Result of a single validation check."""
+
+    status: CheckStatus = Field(..., description="Check status")
+    detail: str = Field("", description="Human-readable detail message")
+    affected: Optional[List[str]] = Field(default_factory=list, description="Affected node identifiers")
+
+
+class TopologyValidationReport(BaseModel):
+    """Structured report produced by the topology validator."""
+
+    psop_id: Optional[str] = Field(None, description="PSOP identifier")
+    psop_name: str = Field(..., description="PSOP name")
+    dag_summary: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Summary of the extracted step graph (nodes, edges, sources, sinks)",
+    )
+    steps: Dict[str, CheckResult] = Field(
+        default_factory=dict,
+        description="Per-step check results keyed by check name",
+    )
+    final_verdict: Verdict = Field(..., description="Aggregated validation verdict")
+    escalation_required: bool = Field(
+        False, description="Whether a break-glass escalation is required to proceed"
+    )
+    errors: List[str] = Field(default_factory=list, description="High-level error messages")
+    warnings: List[str] = Field(default_factory=list, description="Non-blocking warnings")

--- a/orchestrate/validation/topology_validator.py
+++ b/orchestrate/validation/topology_validator.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: Copyright contributors to the OpenAN project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Topology validation for OpenAN Orchestration Center PSOP workflows.
+
+This module implements a lightweight, dependency-free, pre-save validator
+for PSOP workflows. It detects structural problems (cycles, orphans) and
+security-boundary violations inspired by the DeepArchi multi-agent topology
+governance model.
+
+The validator is designed to be invoked synchronously inside the workflow
+CRUD handlers, before persistence or execution.
+"""
+
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from orchestrate.validation.models import (
+    CheckResult,
+    CheckStatus,
+    SecurityLevel,
+    StepSecurity,
+    TopologyValidationInput,
+    TopologyValidationReport,
+    Verdict,
+)
+
+
+def _derive_step_security(
+    step_name: str,
+    step_security_map: Dict[str, StepSecurity],
+    agent_security_map: Dict[str, SecurityLevel],
+    agent_by_step: Dict[str, str],
+) -> SecurityLevel:
+    """Return the security tier of a step.
+
+    Priority:
+    1. explicit step-level metadata
+    2. agent-level metadata for the step's primary agent
+    3. L2_FUNCTIONAL default
+    """
+    if step_name in step_security_map:
+        return step_security_map[step_name].security_level
+    agent = agent_by_step.get(step_name)
+    if agent and agent in agent_security_map:
+        return agent_security_map[agent]
+    return SecurityLevel.L2_FUNCTIONAL
+
+
+def _build_step_graph(steps: List[Any]) -> Tuple[Dict[str, List[str]], Set[str], Set[str]]:
+    """Extract a step-level directed graph from a PSOP.
+
+    Returns (edges, sources, sinks). 'next' jump conditions are used as edges.
+    """
+    edges: Dict[str, List[str]] = defaultdict(list)
+    all_steps: Set[str] = {step.name for step in steps}
+    has_incoming: Set[str] = set()
+
+    for step in steps:
+        targets = step.next or []
+        for jump in targets:
+            if jump.step in all_steps:
+                edges[step.name].append(jump.step)
+                has_incoming.add(jump.step)
+
+    sources = all_steps - has_incoming
+    sinks = {name for name in all_steps if not edges[name]}
+    return dict(edges), sources, sinks
+
+
+def _detect_cycle(
+    edges: Dict[str, List[str]], sources: Set[str]
+) -> Tuple[bool, Optional[List[str]]]:
+    """Return (has_cycle, path) using DFS with stack-based traceback."""
+    visited: Set[str] = set()
+    rec_stack: Set[str] = set()
+    path: List[str] = []
+
+    def dfs(node: str) -> Tuple[bool, Optional[List[str]]]:
+        visited.add(node)
+        rec_stack.add(node)
+        path.append(node)
+        for neighbor in edges.get(node, []):
+            if neighbor not in visited:
+                found, cycle = dfs(neighbor)
+                if found:
+                    return True, cycle
+            elif neighbor in rec_stack:
+                idx = path.index(neighbor)
+                cycle = path[idx:] + [neighbor]
+                return True, cycle
+        path.pop()
+        rec_stack.remove(node)
+        return False, None
+
+    for start in list(sources) + [n for n in edges if n not in visited]:
+        if start not in visited:
+            found, cycle = dfs(start)
+            if found:
+                return True, cycle
+    return False, None
+
+
+def _compute_blast_radius(
+    edges: Dict[str, List[str]], start: str, max_depth: int
+) -> Set[str]:
+    """Return all reachable downstream steps up to max_depth from start."""
+    visited: Set[str] = set()
+    frontier: List[Tuple[str, int]] = [(start, 0)]
+    while frontier:
+        node, depth = frontier.pop()
+        if depth > max_depth or node in visited:
+            continue
+        visited.add(node)
+        for neighbor in edges.get(node, []):
+            frontier.append((neighbor, depth + 1))
+    visited.discard(start)
+    return visited
+
+
+def _run_cycle_check(
+    edges: Dict[str, List[str]], sources: Set[str]
+) -> CheckResult:
+    has_cycle, cycle = _detect_cycle(edges, sources)
+    if has_cycle and cycle:
+        return CheckResult(
+            status=CheckStatus.REJECT,
+            detail=f"Cycle detected: {' -> '.join(cycle)}",
+            affected=cycle,
+        )
+    return CheckResult(status=CheckStatus.PASS, detail="No cycles detected")
+
+
+def _run_orphan_check(
+    edges: Dict[str, List[str]], all_steps: Set[str], sources: Set[str], sinks: Set[str]
+) -> CheckResult:
+    isolated = {s for s in all_steps if s in sources and s in sinks}
+    if isolated:
+        return CheckResult(
+            status=CheckStatus.WARN,
+            detail=f"Isolated steps (no incoming or outgoing edges): {sorted(isolated)}",
+            affected=sorted(isolated),
+        )
+    return CheckResult(status=CheckStatus.PASS, detail="No isolated steps")
+
+
+def _run_security_boundary_check(
+    edges: Dict[str, List[str]],
+    step_security_map: Dict[str, StepSecurity],
+    agent_security_map: Dict[str, SecurityLevel],
+    agent_by_step: Dict[str, str],
+) -> CheckResult:
+    """Detect L2/L3 -> L1 upstream delegation.
+
+    Lower-trust steps must not pass data upward to higher-trust strategic
+    steps unless break-glass is explicitly enabled on the target step.
+    """
+    numeric_tier = {
+        SecurityLevel.L1_STRATEGIC: 1,
+        SecurityLevel.L2_FUNCTIONAL: 2,
+        SecurityLevel.L3_EXTERNAL: 3,
+    }
+    violations: List[str] = []
+    for source, targets in edges.items():
+        source_tier = numeric_tier[_derive_step_security(
+            source, step_security_map, agent_security_map, agent_by_step
+        )]
+        for target in targets:
+            target_security = step_security_map.get(target)
+            break_glass = target_security.break_glass if target_security else False
+            target_tier = numeric_tier[_derive_step_security(
+                target, step_security_map, agent_security_map, agent_by_step
+            )]
+            if source_tier > target_tier and not break_glass:
+                violations.append(f"{source}({source_tier}) -> {target}({target_tier})")
+    if violations:
+        return CheckResult(
+            status=CheckStatus.REJECT,
+            detail=f"Security boundary violation(s): {violations}",
+            affected=violations,
+        )
+    return CheckResult(
+        status=CheckStatus.PASS, detail="No upstream delegation violations"
+    )
+
+
+def _run_blast_radius(
+    edges: Dict[str, List[str]], max_depth: int
+) -> CheckResult:
+    radii: Dict[str, List[str]] = {
+        start: sorted(_compute_blast_radius(edges, start, max_depth))
+        for start in edges
+    }
+    max_affected = max((len(v) for v in radii.values()), default=0)
+    detail = f"Max downstream blast radius up to depth {max_depth}: {max_affected} steps"
+    return CheckResult(
+        status=CheckStatus.PASS,
+        detail=detail,
+        affected=[k for k, v in radii.items() if len(v) == max_affected],
+    )
+
+
+def validate_topology(
+    input_data: TopologyValidationInput,
+) -> TopologyValidationReport:
+    """Validate a PSOP workflow before persistence or execution.
+
+    Args:
+        input_data: TopologyValidationInput containing the PSOP and optional
+            security metadata.
+
+    Returns:
+        TopologyValidationReport with per-step results and aggregated verdict.
+    """
+    psop = input_data.psop
+    steps = psop.steps
+    step_names = {step.name for step in steps}
+
+    agent_by_step: Dict[str, str] = {}
+    for step in steps:
+        if step.subtasks:
+            agent_by_step[step.name] = step.subtasks[0].agent
+
+    edges, sources, sinks = _build_step_graph(steps)
+
+    check_results: Dict[str, CheckResult] = {}
+    check_results["cycle_check"] = _run_cycle_check(edges, sources)
+    check_results["orphan_check"] = _run_orphan_check(edges, step_names, sources, sinks)
+    check_results["security_boundary_check"] = _run_security_boundary_check(
+        edges,
+        input_data.step_security or {},
+        input_data.agent_security or {},
+        agent_by_step,
+    )
+    check_results["blast_radius"] = _run_blast_radius(
+        edges, input_data.max_blast_radius_depth
+    )
+
+    dag_summary = {
+        "nodes": sorted(step_names),
+        "edges": {k: sorted(v) for k, v in sorted(edges.items())},
+        "sources": sorted(sources),
+        "sinks": sorted(sinks),
+    }
+
+    errors: List[str] = []
+    warnings: List[str] = []
+    for name, result in check_results.items():
+        if result.status == CheckStatus.REJECT:
+            errors.append(f"{name}: {result.detail}")
+        elif result.status == CheckStatus.WARN:
+            warnings.append(f"{name}: {result.detail}")
+
+    final_verdict = Verdict.APPROVE
+    if errors:
+        final_verdict = Verdict.REJECT
+    elif warnings:
+        final_verdict = Verdict.APPROVE_WITH_CONDITIONS
+
+    escalation_required = any(
+        (step_security.break_glass for step_security in (input_data.step_security or {}).values())
+    )
+
+    return TopologyValidationReport(
+        psop_id=psop.id,
+        psop_name=psop.name,
+        dag_summary=dag_summary,
+        steps=check_results,
+        final_verdict=final_verdict,
+        escalation_required=escalation_required,
+        errors=errors,
+        warnings=warnings,
+    )

--- a/tests/test_topology_validator.py
+++ b/tests/test_topology_validator.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright contributors to the OpenAN project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the topology validator.
+
+These tests verify cycle detection, orphan detection, security boundary
+validation, and blast-radius computation using the PSOP pydantic model.
+"""
+
+import pytest
+
+from orchestrate.core.model.psop import PSOP, Step, Task, JumpCondition
+from orchestrate.validation.models import (
+    CheckStatus,
+    SecurityLevel,
+    StepSecurity,
+    TopologyValidationInput,
+    Verdict,
+)
+from orchestrate.validation.topology_validator import validate_topology
+
+
+def _make_step(name: str, agent: str, next_steps: list = None, layer: int = 0) -> Step:
+    return Step(
+        name=name,
+        subtasks=[Task(description=f"task {name}", agent=agent, skill=f"skill-{name}")],
+        next=[JumpCondition(step=t, condition="") for t in (next_steps or [])] or None,
+        layer=layer,
+    )
+
+
+def test_linear_psop_approves():
+    psop = PSOP(
+        name="linear",
+        steps=[
+            _make_step("s1", "agent-a", next_steps=["s2"]),
+            _make_step("s2", "agent-b", next_steps=["s3"]),
+            _make_step("s3", "agent-c"),
+        ],
+    )
+    report = validate_topology(TopologyValidationInput(psop=psop))
+    assert report.final_verdict == Verdict.APPROVE
+    assert report.steps["cycle_check"].status == CheckStatus.PASS
+    assert report.steps["security_boundary_check"].status == CheckStatus.PASS
+
+
+def test_cycle_rejects():
+    psop = PSOP(
+        name="cycle",
+        steps=[
+            _make_step("s1", "agent-a", next_steps=["s2"]),
+            _make_step("s2", "agent-b", next_steps=["s3"]),
+            _make_step("s3", "agent-c", next_steps=["s1"]),
+        ],
+    )
+    report = validate_topology(TopologyValidationInput(psop=psop))
+    assert report.final_verdict == Verdict.REJECT
+    assert report.steps["cycle_check"].status == CheckStatus.REJECT
+
+
+def test_orphan_warns():
+    psop = PSOP(
+        name="orphan",
+        steps=[
+            _make_step("s1", "agent-a", next_steps=["s2"]),
+            _make_step("s2", "agent-b"),
+            _make_step("s3", "agent-c"),  # isolated
+        ],
+    )
+    report = validate_topology(TopologyValidationInput(psop=psop))
+    assert report.final_verdict == Verdict.APPROVE_WITH_CONDITIONS
+    assert report.steps["orphan_check"].status == CheckStatus.WARN
+
+
+def test_l2_to_l1_upstream_rejects():
+    psop = PSOP(
+        name="upward-violation",
+        steps=[
+            _make_step("l2_step", "agent-l2", next_steps=["l1_step"]),
+            _make_step("l1_step", "agent-l1"),
+        ],
+    )
+    security = {
+        "l2_step": StepSecurity(step_name="l2_step", security_level=SecurityLevel.L2_FUNCTIONAL),
+        "l1_step": StepSecurity(step_name="l1_step", security_level=SecurityLevel.L1_STRATEGIC),
+    }
+    report = validate_topology(TopologyValidationInput(psop=psop, step_security=security))
+    assert report.final_verdict == Verdict.REJECT
+    assert report.steps["security_boundary_check"].status == CheckStatus.REJECT
+
+
+def test_l1_to_l2_downstream_allows():
+    psop = PSOP(
+        name="downward-ok",
+        steps=[
+            _make_step("l1_step", "agent-l1", next_steps=["l2_step"]),
+            _make_step("l2_step", "agent-l2"),
+        ],
+    )
+    security = {
+        "l1_step": StepSecurity(step_name="l1_step", security_level=SecurityLevel.L1_STRATEGIC),
+        "l2_step": StepSecurity(step_name="l2_step", security_level=SecurityLevel.L2_FUNCTIONAL),
+    }
+    report = validate_topology(TopologyValidationInput(psop=psop, step_security=security))
+    assert report.final_verdict == Verdict.APPROVE
+    assert report.steps["security_boundary_check"].status == CheckStatus.PASS
+
+
+def test_break_glass_allows_l2_to_l1():
+    psop = PSOP(
+        name="break-glass",
+        steps=[
+            _make_step("l2_step", "agent-l2", next_steps=["l1_step"]),
+            _make_step("l1_step", "agent-l1"),
+        ],
+    )
+    security = {
+        "l2_step": StepSecurity(step_name="l2_step", security_level=SecurityLevel.L2_FUNCTIONAL),
+        "l1_step": StepSecurity(
+            step_name="l1_step",
+            security_level=SecurityLevel.L1_STRATEGIC,
+            break_glass=True,
+        ),
+    }
+    report = validate_topology(TopologyValidationInput(psop=psop, step_security=security))
+    assert report.final_verdict == Verdict.APPROVE
+    assert report.steps["security_boundary_check"].status == CheckStatus.PASS
+    assert report.escalation_required is True
+
+
+def test_blast_radius_computed():
+    psop = PSOP(
+        name="blast",
+        steps=[
+            _make_step("root", "agent-root", next_steps=["a", "b"]),
+            _make_step("a", "agent-a", next_steps=["c"]),
+            _make_step("b", "agent-b", next_steps=["c"]),
+            _make_step("c", "agent-c"),
+        ],
+    )
+    report = validate_topology(TopologyValidationInput(psop=psop, max_blast_radius_depth=3))
+    assert report.steps["blast_radius"].status == CheckStatus.PASS
+    assert "3 steps" in report.steps["blast_radius"].detail
+    assert "root" in report.steps["blast_radius"].affected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

This PR adds a lightweight, in-process topology validator for Orchestration Center PSOP workflows. It detects structural and governance problems before a workflow is persisted or executed, reducing runtime failures and unsafe delegation chains.

## Validation Checks

| Check | Rule | Failure |
|-------|------|---------|
| cycle_check | No directed cycles in the step graph | reject |
| orphan_check | Steps with no incoming and no outgoing edges | warn |
| security_boundary_check | L2/L3 -> L1 upstream edges are forbidden unless break-glass is set | reject |
| blast_radius | Downstream affected steps up to configurable depth | risk label |

## Files Added

- `orchestrate/validation/__init__.py`
- `orchestrate/validation/models.py`
- `orchestrate/validation/topology_validator.py`
- `orchestrate/validation/hooks.py`
- `tests/test_topology_validator.py`

## Integration Example

```python
from orchestrate.validation.hooks import validate_before_save

@router.post("/workflows")
async def create_workflow(psop: PSOP):
    await validate_before_save(psop)
    # ... persist
```

## Testing

Run the new test file from a properly configured environment:

```bash
python -m pytest tests/test_topology_validator.py -q
```

Result: **7 passed**.

## Non-Goals

- No dependency on vector DB or LLM.
- No network calls; runs in-process.
- Design-time guard only; not a replacement for runtime mTLS/signature validation.

## Related Issue

Closes #43

---

Contributed by **DeepArchi/深度架构**.

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] All commits are signed off per the DCO
- [x] New tests pass locally
- [x] New source files include the SPDX license header
