### PR TITLE
test: restore parse-pdf endpoint coverage

### DIFF
--- a/tests/test_frontend_support_server.py
+++ b/tests/test_frontend_support_server.py
@@ -89,51 +89,68 @@ class TestParsePdfEndpoint:
         response = client.post(f'{BASE}/parse-pdf')
         assert response.status_code == 422
 
-    @pytest.mark.skip(reason='PDF parsing tests are temporarily disabled')
     def test_parse_pdf_empty_filename(self, client):
-        """Test empty filename"""
-        response = client.post(f'{BASE}/parse-pdf', data={'file': (BytesIO(), '')})
-        assert response.status_code == 400
+        """Test empty filename.
 
-    @pytest.mark.skip(reason='PDF parsing tests are temporarily disabled')
+        httpx's files= helper drops an empty filename from the multipart
+        Content-Disposition header entirely, which FastAPI then rejects at
+        the schema-validation layer (422) before the handler ever runs. To
+        actually exercise the handler's own `if not file.filename` check we
+        need to send a raw multipart body with filename="" explicit.
+        """
+        body = (
+            b'--boundary123\r\n'
+            b'Content-Disposition: form-data; name="file"; filename=""\r\n'
+            b'Content-Type: application/octet-stream\r\n\r\n'
+            b'\r\n'
+            b'--boundary123--\r\n'
+        )
+        response = client.post(
+            f'{BASE}/parse-pdf',
+            content=body,
+            headers={'Content-Type': 'multipart/form-data; boundary=boundary123'},
+        )
+        assert response.status_code == 400
+        assert 'Filename is required' in response.json()['message']
+
     def test_parse_pdf_wrong_extension(self, client):
         """Test non-PDF file"""
-        response = client.post(f'{BASE}/parse-pdf', data={
-            'file': (BytesIO(b'test'), 'test.txt')
+        response = client.post(f'{BASE}/parse-pdf', files={
+            'file': ('test.txt', BytesIO(b'test'))
         })
         assert response.status_code == 400
         data = response.json()
-        assert 'Only PDF supported' in data['error']
+        assert 'Invalid filename format' in data['message']
 
-    @pytest.mark.skip(reason='PDF parsing tests are temporarily disabled')
+    def test_parse_pdf_not_pdf_content(self, client):
+        """Test a .pdf-named file whose content isn't a real PDF"""
+        response = client.post(f'{BASE}/parse-pdf', files={
+            'file': ('test.pdf', BytesIO(b'not a pdf'))
+        })
+        assert response.status_code == 400
+        assert 'not a valid PDF' in response.json()['message']
+
     def test_parse_pdf_success(self, client, mock_parser):
         """Test successful PDF parsing"""
         mock_parser.parse_pdf_chapter.return_value = "# Test Markdown"
 
-        with patch('orchestrate.server.frontend_support_server.PreFlow') as MockPreFlow:
-            mock_preflow = MagicMock()
-            mock_preflow.model_dump_json.return_value = '{"name": "test"}'
-            MockPreFlow.return_value = mock_preflow
+        response = client.post(f'{BASE}/parse-pdf', files={
+            'file': ('test.pdf', BytesIO(b'%PDF-1.4 test'))
+        })
 
-            response = client.post(f'{BASE}/parse-pdf', data={
-                'file': (BytesIO(b'%PDF-1.4 test'), 'test.pdf')
-            })
+        assert response.status_code == 200
+        assert response.json()['data']['steps_md'] == "# Test Markdown"
 
-            # Note: original code returns a dict, not jsonify; testing actual behavior
-            assert response.status_code == 200
-
-    @pytest.mark.skip(reason='PDF parsing tests are temporarily disabled')
     def test_parse_pdf_parse_failure(self, client, mock_parser):
-        """Test parsing failure"""
+        """Test parsing failure (chapter not found)"""
         mock_parser.parse_pdf_chapter.return_value = None
 
-        response = client.post(f'{BASE}/parse-pdf', data={
-            'file': (BytesIO(b'%PDF-1.4 test'), 'test.pdf')
+        response = client.post(f'{BASE}/parse-pdf', files={
+            'file': ('test.pdf', BytesIO(b'%PDF-1.4 test'))
         })
 
         assert response.status_code == 400
-        data = response.json()
-        assert 'Parsing failed' in data['error']
+        assert 'not found in PDF' in response.json()['message']
 
 
 class TestPlanEndpoint:


### PR DESCRIPTION
## Description

Re-enables the four `/parse-pdf` endpoint tests in `tests/test_frontend_support_server.py`, which were previously disabled with `@pytest.mark.skip` and were independently broken:

- They used the old `requests`-style `data={file: (BytesIO, filename)}` multipart syntax, which the current httpx-based FastAPI `TestClient` doesn't support (wrong argument, wrong tuple order).
- They asserted against a response shape (`data['error']`, `"Only PDF supported"`) that doesn't match what the endpoint actually returns (`message` key, `"Invalid filename format"`).

Fixed by switching to `files={'file': (filename, BytesIO)}` and asserting against the real response envelope. The empty-filename case needed a raw multipart body instead of the `files=` helper, since httpx drops an empty filename from the `Content-Disposition` header entirely and FastAPI then 422s before the handler's own check ever runs.

Covers: empty filenames, invalid extensions, successful parsing, and parser failure.

## Related Issue(s)

NA.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

Verified locally: `tests/test_frontend_support_server.py` — 20 passed, 7 skipped (pre-existing, unrelated skips), 0 failures.