### PR TITLE
fix: improve dependency installation reliability in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY requirements.txt /tmp/requirements.txt
 
 RUN python3 -m venv /opt/venv --copies \
     && . /opt/venv/bin/activate \
-    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && pip install --no-cache-dir --default-timeout=180 --retries=10 -r /tmp/requirements.txt \
     && rm -rf /tmp/requirements.txt /root/.cache/pip
 
 FROM python:3.12-slim


### PR DESCRIPTION
## Description

Raises pip's download timeout to 180 seconds and allows 10 retries during the Docker build's dependency install step. Large wheels (e.g. PyMuPDF) were timing out mid-download from files.pythonhosted.org, failing the build with no retry.

## Related Issue(s)

NA.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [ ] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

Single-line change to the `pip install` invocation in `Dockerfile`; no test coverage applicable (build-time flag only).

Recreates #46, which EasyCLA flagged as unauthorized despite the identical author/commit signature passing on #45.