### PR TITLE
feat: integrate orchestration-center with the OpenAN compose network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN python3 -m venv /opt/venv --copies \
 
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends bash libpq5 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends bash libpq5 curl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/venv /opt/venv
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,48 @@ python -m samples.start_agents_server
 | Frontend | Open `http://localhost:3003` in browser |
 | Sample Agents | Agent startup messages in console |
 
+## Docker Deployment
+
+Orchestration Center is one of three OpenAN components meant to run together
+(`orchestration-center`, [`registry-center`](https://github.com/hw-irc-sni/registry-center),
+[`prompt-registry`](https://github.com/hw-irc-sni/prompt-registry)), sharing
+the `openan-net` Docker network so agent cards resolve by container name.
+
+**One-time setup** (once for all three components, not per-repo):
+```bash
+docker network create openan-net
+```
+
+**Production** — `docker-compose.yml` only:
+```bash
+docker compose up -d --build
+```
+Talks to registry-center over HTTPS at `https://openan-registry-center:5000`
+(registry-center is HTTPS-by-default in production — see its README). Start
+registry-center's stack first, or this container will log connection errors
+until that hostname resolves and answers.
+
+**Development** — layers `docker-compose-dev.yml` on top, which switches
+`AGENT_REGISTRY_URL` to plain HTTP to match registry-center's dev stack
+(HTTPS disabled there — see that repo's `docker-compose-dev.yml`):
+```bash
+docker compose -f docker-compose.yml -f docker-compose-dev.yml up -d --build
+```
+
+Every value in `environment:` reads from the host shell (or a `.env` file
+next to the compose file) first, falling back to the default shown in the
+file — e.g. `AGENT_REGISTRY_URL=https://a-different-host:5000 docker compose up -d`
+overrides it without editing the file.
+
+> Keep the two components on the same "track" — both production files
+> together, or both dev files together. Mixing a production
+> `registry-center` (HTTPS) with a dev `orchestration-center` pointed at
+> `http://` (or vice versa) will fail the TLS handshake.
+
+`prompt-registry` has no wiring to the other two today — join it to
+`openan-net` for future integration, but it can be started independently in
+any order.
+
 ## Architecture
 
 ```mermaid

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,11 @@
+# Development override for docker-compose.yml. Not auto-loaded — run with:
+#   docker compose -f docker-compose.yml -f docker-compose-dev.yml up -d
+#
+# Points at registry-center's dev stack, which disables HTTPS (see
+# registry-center/docker-compose-dev.yml) — so this must use http, not the
+# production file's https, or every agent-cards request will fail the TLS
+# handshake against a plaintext listener.
+services:
+  orchestration-center:
+    environment:
+      - AGENT_REGISTRY_URL=${AGENT_REGISTRY_URL:-http://openan-registry-center:5000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
-version: "3.8"
-
 services:
   orchestration-center:
     build: .
-    container_name: orchestration-center
+    container_name: openan-orchestration-center
     ports:
       - "5001:5001"
     volumes:
@@ -11,11 +9,19 @@ services:
       - ./etc/ssl:/opt/orchestration-center/etc/ssl
       - ./log:/opt/orchestration-center/log
     environment:
-      - ORCH_IP=0.0.0.0
-      - ORCH_PORT=5001
-      - ORCH_ENABLE_HTTPS=false
-      - ORCH_FORWARDED_ALLOW_IPS=*
-      - PERSISTENCE_MODE=file
+      - ORCH_IP=${ORCH_IP:-0.0.0.0}
+      - ORCH_PORT=${ORCH_PORT:-5001}
+      - ORCH_ENABLE_HTTPS=${ORCH_ENABLE_HTTPS:-false}
+      - ORCH_FORWARDED_ALLOW_IPS=${ORCH_FORWARDED_ALLOW_IPS:-*}
+      - PERSISTENCE_MODE=${PERSISTENCE_MODE:-file}
+      # registry-center is HTTPS-by-default in production (see that repo's
+      # docker-compose.yml); client_verify_server defaults false so the
+      # self-signed cert doesn't need trusting. Requires registry-center's
+      # openan-registry-center container reachable on openan-net — start
+      # that stack first.
+      - AGENT_REGISTRY_URL=${AGENT_REGISTRY_URL:-https://openan-registry-center:5000}
+    networks:
+      - openan-net
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5001/rest/v1/orchestrate/agent-cards"]
       interval: 30s
@@ -36,14 +42,20 @@ services:
   #
   # postgres:
   #   image: postgres:15-alpine
-  #   container_name: orchestration-postgres
+  #   container_name: openan-orchestration-center-postgres
   #   environment:
-  #     - POSTGRES_DB=orchestration_center
-  #     - POSTGRES_USER=opena2a_t
-  #     - POSTGRES_PASSWORD=openA2A_T
+  #     - POSTGRES_DB=${DB_NAME:-orchestration_center}
+  #     - POSTGRES_USER=${DB_USERNAME:-opena2a_t}
+  #     - POSTGRES_PASSWORD=${DB_PASSWORD:-openA2A_T}
   #   volumes:
   #     - pgdata:/var/lib/postgresql/data
+  #   networks:
+  #     - openan-net
   #   restart: unless-stopped
   #
   # volumes:
   #   pgdata:
+
+networks:
+  openan-net:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,11 @@ services:
     networks:
       - openan-net
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5001/rest/v1/orchestrate/agent-cards"]
+      # -k: ORCH_ENABLE_HTTPS defaults to a self-signed cert, which curl won't
+      # trust without it. Scheme follows ORCH_ENABLE_HTTPS -- the backend only
+      # listens on one protocol per port, so a plain http:// check against an
+      # HTTPS-only server would report unhealthy forever.
+      test: ["CMD-SHELL", "curl -kf http$$([ \"$$ORCH_ENABLE_HTTPS\" = true ] && echo s)://localhost:5001/rest/v1/orchestrate/agent-cards"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Description

Connects orchestration-center to the shared `openan-net` Docker network for production and development Compose stacks:

- Uses `openan-registry-center` as the default registry endpoint.
- Adds an HTTP registry override for development (`docker-compose-dev.yml`, run with `docker compose -f docker-compose.yml -f docker-compose-dev.yml up -d` — not auto-loaded).
- Makes Compose environment values host-overridable (`${VAR:-default}`).
- Installs `curl` in the runtime image so the health check can run.

Also fixes a bug found while validating this PR's own checklist: the health check curled `http://localhost:5001` unconditionally, but the backend listens on exactly one protocol per port — with `ORCH_ENABLE_HTTPS=true` it only speaks TLS, so the check would report the container unhealthy forever despite the service running fine. The health check's scheme now follows `ORCH_ENABLE_HTTPS`, with `-k` for the self-signed cert that's the HTTPS default.

## Related Issue(s)

NA.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [ ] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

Validated locally:
- `docker compose -f docker-compose.yml config` — succeeds (production).
- `docker compose -f docker-compose.yml -f docker-compose-dev.yml config` — succeeds (development override).
- Health check scheme-switching verified against a throwaway container for both `ORCH_ENABLE_HTTPS=true` and `=false` — confirms the `$$`-escaped shell expression reaches the container instead of being resolved away by Compose's own `$VAR` interpolation.
- `pytest tests/` (excluding the two live-HTTP integration files) — 271 passed, 7 pre-existing skips, 0 failures.

Not yet validated (from the original issue's checklist, out of scope for this pass): behavior when `openan-net` doesn't exist yet, whether fixed `container_name` values should remain, and registry-center-unavailable behavior.