### PR TITLE
feat: run sample agent fleet in the development compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,30 @@ until that hostname resolves and answers.
 
 **Development** — layers `docker-compose-dev.yml` on top, which switches
 `AGENT_REGISTRY_URL` to plain HTTP to match registry-center's dev stack
-(HTTPS disabled there — see that repo's `docker-compose-dev.yml`):
+(HTTPS disabled there — see that repo's `docker-compose-dev.yml`), and also
+brings up a `sample-agents` service (the stub demo agents from
+`samples/agentcard/*.json`) so workflow execution has something to call:
 ```bash
 docker compose -f docker-compose.yml -f docker-compose-dev.yml up -d --build
 ```
+`sample-agents` runs the same image with `python3 -m samples.start_agents_server`
+and `SAMPLE_AGENTS_HOST=sample-agents`, which makes it advertise and register
+its cards under that Compose service name instead of the `127.0.0.1` baked
+into the JSON files (only correct when both processes share a host, which
+containers don't). It's dev-only and intentionally absent from
+`docker-compose.yml` — these are stub agents, not production backends.
+
+> Don't run this `sample-agents` container and a host-run
+> `python -m samples.start_agents_server` (`bin/start_samples.sh`) against the
+> same registry at the same time — each registers its own card URLs
+> (`sample-agents:PORT` vs `127.0.0.1:PORT`) and whichever started last wins,
+> silently breaking calls from the other.
+
+Negotiation-capable sample agents need real chat-model credentials to do
+anything past startup — `common/config/llm_config.json` ships with a
+placeholder API key. Pass `LLM_CHAT_MODEL`/`LLM_CHAT_API_KEY`/`LLM_CHAT_URL`
+(host shell or a `.env` next to the compose file) to `sample-agents` for
+negotiation to actually work, not just for the container to start green.
 
 Every value in `environment:` reads from the host shell (or a `.env` file
 next to the compose file) first, falling back to the default shown in the

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,3 +9,36 @@ services:
   orchestration-center:
     environment:
       - AGENT_REGISTRY_URL=${AGENT_REGISTRY_URL:-http://openan-registry-center:5000}
+
+  # ---- Optional: sample A2A agent fleet (stub demo agents) ----
+  # Same image, different command. These cards give workflow execution
+  # real endpoints to call; without them, executions have nothing to talk
+  # to. Cards under samples/agentcard/*.json hardcode 127.0.0.1, which only
+  # resolves correctly when both processes share a host — SAMPLE_AGENTS_HOST
+  # makes the sample server advertise (and register with the registry) this
+  # service's Compose DNS name instead, so orchestration-center's container
+  # can reach it. Dev-only and deliberately absent from docker-compose.yml:
+  # these are stub agents, not real production backends, and registering
+  # their loopback-free URLs into a shared prod registry would still be the
+  # wrong thing to do even if the networking worked.
+  sample-agents:
+    build: .
+    container_name: openan-orchestration-center-sample-agents
+    command: ["python3", "-m", "samples.start_agents_server"]
+    environment:
+      - SAMPLE_AGENTS_HOST=sample-agents
+      - AGENT_REGISTRY_URL=${AGENT_REGISTRY_URL:-http://openan-registry-center:5000}
+      - PERSISTENCE_MODE=file
+      # Negotiation-capable sample agents need a real chat model to do
+      # anything past startup; common/config/llm_config.json ships with a
+      # placeholder API key. Set these in the host shell or a .env next to
+      # this file to point at a real provider.
+      - LLM_CHAT_MODEL=${LLM_CHAT_MODEL:-}
+      - LLM_CHAT_API_KEY=${LLM_CHAT_API_KEY:-}
+      - LLM_CHAT_URL=${LLM_CHAT_URL:-}
+    ports:
+      - "8899-8904:8899-8904"
+      - "26335-26336:26335-26336"
+    networks:
+      - openan-net
+    restart: unless-stopped

--- a/samples/start_agents_server.py
+++ b/samples/start_agents_server.py
@@ -251,7 +251,28 @@ async def start_server(agent_card: AgentCard, port: int, host: str = "127.0.0.1"
         pass
 
 
+def _warn_if_chat_llm_unconfigured() -> None:
+    """Negotiation-capable sample agents need a real chat model. Agents still
+    start without one (see common/llm/config/llm_config.py's degrade-not-crash
+    guard) but every negotiation call will fail, so make that loud at startup
+    instead of leaving it to surface as a per-call error later."""
+    try:
+        from common.llm.config.llm_config import get_model_config, missing_required_fields, describe_missing_fields
+
+        config = get_model_config("chat")
+        missing = missing_required_fields(config) if config else ["url", "model", "api_key"]
+        if missing:
+            logger.warning(
+                f"Sample agents starting without a configured chat LLM: "
+                f"{describe_missing_fields('chat', missing)}"
+            )
+    except Exception as e:
+        logger.warning(f"Could not verify chat LLM configuration at startup: {e}")
+
+
 async def main() -> None:
+    _warn_if_chat_llm_unconfigured()
+
     try:
         pre_insert_psop()
     except Exception as e:

--- a/samples/start_agents_server.py
+++ b/samples/start_agents_server.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import json
+import os
 import signal
 from pathlib import Path
 
@@ -30,7 +31,7 @@ from starlette.responses import JSONResponse
 from google.protobuf.json_format import MessageToDict
 from loguru import logger
 from typing import List
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 from common.custom import HandlerRegistry, InterfaceType
 from orchestrate.registry_client.client_factory import AgentRegistryClientFactory
@@ -58,6 +59,19 @@ _agent_executors = []
 
 def _agent_card_to_dict(agent_card: AgentCard) -> dict:
     return MessageToDict(agent_card)
+
+
+def _override_advertised_host(agent_card: AgentCard, host: str) -> None:
+    """Rewrite the host each interface URL advertises (for registration and
+    for other containers to call back), independent of what uvicorn binds to.
+    Loopback-hardcoded sample agent cards otherwise only work when the caller
+    shares the host with the agent process."""
+    for iface in agent_card.supported_interfaces:
+        if not iface.url:
+            continue
+        parsed = urlparse(iface.url)
+        netloc = f"{host}:{parsed.port}" if parsed.port else host
+        iface.url = urlunparse(parsed._replace(netloc=netloc))
 
 
 def _is_agent_card_changed(local_dict: dict, remote_dict: dict) -> bool:
@@ -250,6 +264,16 @@ async def main() -> None:
         logger.error(f"Failed to load agent cards: {e}")
         return
 
+    # SAMPLE_AGENTS_HOST lets these cards advertise a Docker service name (or
+    # any reachable host) instead of the hardcoded 127.0.0.1 from the JSON,
+    # so a container other than this one can reach and register them. Unset,
+    # behavior is unchanged (loopback, same-host processes).
+    advertise_host = os.environ.get("SAMPLE_AGENTS_HOST", "").strip()
+    if advertise_host:
+        for agent_card in agent_cards:
+            _override_advertised_host(agent_card, advertise_host)
+        logger.info(f"Advertising sample agent cards on host '{advertise_host}'")
+
     factory = None
     try:
         factory = AgentRegistryClientFactory().create_from_env()
@@ -269,8 +293,12 @@ async def main() -> None:
             logger.warning(f"Skipping agent '{agent_name}': no supported interfaces")
             continue
         parsed = urlparse(agent_card.supported_interfaces[0].url)
+        # Bind to all interfaces when advertising a different host (a Docker
+        # service name isn't a local bind address); otherwise bind exactly
+        # what the card says, matching prior same-host behavior.
+        bind_host = "0.0.0.0" if advertise_host else parsed.hostname
         task = asyncio.create_task(
-            start_server(agent_card, port=parsed.port, host=parsed.hostname),
+            start_server(agent_card, port=parsed.port, host=bind_host),
             name=f"server_{agent_name}"
         )
         tasks.append(task)

--- a/tests/test_start_agents_server.py
+++ b/tests/test_start_agents_server.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from unittest.mock import MagicMock, patch
+
+from a2a.types import AgentCard, AgentInterface
+
+from samples.start_agents_server import _override_advertised_host, _warn_if_chat_llm_unconfigured
+
+
+def _card(*urls):
+    return AgentCard(
+        name="test-agent",
+        supported_interfaces=[AgentInterface(url=url) for url in urls],
+    )
+
+
+class TestOverrideAdvertisedHost:
+    def test_rewrites_host_keeps_port(self):
+        card = _card("http://127.0.0.1:8899/a2a/v1")
+        _override_advertised_host(card, "sample-agents")
+        assert card.supported_interfaces[0].url == "http://sample-agents:8899/a2a/v1"
+
+    def test_rewrites_host_without_port(self):
+        card = _card("http://127.0.0.1/a2a/v1")
+        _override_advertised_host(card, "sample-agents")
+        assert card.supported_interfaces[0].url == "http://sample-agents/a2a/v1"
+
+    def test_preserves_scheme_path_and_query(self):
+        card = _card("https://127.0.0.1:26335/rest/plat/smapp/v1/oauth/token?x=1")
+        _override_advertised_host(card, "sample-agents")
+        iface = card.supported_interfaces[0]
+        assert iface.url == "https://sample-agents:26335/rest/plat/smapp/v1/oauth/token?x=1"
+
+    def test_rewrites_every_interface_on_the_card(self):
+        card = _card(
+            "http://127.0.0.1:8899/a2a/v1",
+            "http://127.0.0.1:8899/a2a/v2",
+        )
+        _override_advertised_host(card, "sample-agents")
+        assert [i.url for i in card.supported_interfaces] == [
+            "http://sample-agents:8899/a2a/v1",
+            "http://sample-agents:8899/a2a/v2",
+        ]
+
+    def test_skips_interfaces_with_no_url(self):
+        card = _card("")
+        _override_advertised_host(card, "sample-agents")
+        assert card.supported_interfaces[0].url == ""
+
+    def test_no_interfaces_is_a_noop(self):
+        card = AgentCard(name="test-agent", supported_interfaces=[])
+        _override_advertised_host(card, "sample-agents")
+        assert list(card.supported_interfaces) == []
+
+    def test_host_is_expected_to_be_bare_not_host_colon_port(self):
+        # SAMPLE_AGENTS_HOST is documented/used as a bare hostname (Docker service
+        # name). A host that already carries its own port gets the original URL's
+        # port appended after it too, producing a malformed netloc -- this is
+        # current behavior, not a supported input.
+        card = _card("http://127.0.0.1:8899/a2a/v1")
+        _override_advertised_host(card, "sample-agents:9000")
+        assert card.supported_interfaces[0].url == "http://sample-agents:9000:8899/a2a/v1"
+
+
+class TestWarnIfChatLlmUnconfigured:
+    def test_warns_when_required_fields_are_placeholders(self):
+        config = MagicMock(url="<YOUR_URL>", model="<YOUR_MODEL>", api_key="<YOUR_API_KEY>")
+        with patch("common.llm.config.llm_config.get_model_config", return_value=config), \
+             patch("samples.start_agents_server.logger") as mock_logger:
+            _warn_if_chat_llm_unconfigured()
+        assert mock_logger.warning.called
+        message = mock_logger.warning.call_args[0][0]
+        assert "url" in message and "model" in message and "api_key" in message
+
+    def test_no_warning_when_fully_configured(self):
+        config = MagicMock(url="https://api.openai.com/v1/chat/completions", model="gpt-4o", api_key="sk-real")
+        with patch("common.llm.config.llm_config.get_model_config", return_value=config), \
+             patch("samples.start_agents_server.logger") as mock_logger:
+            _warn_if_chat_llm_unconfigured()
+        mock_logger.warning.assert_not_called()
+
+    def test_warns_when_chat_capability_missing_entirely(self):
+        with patch("common.llm.config.llm_config.get_model_config", return_value=None), \
+             patch("samples.start_agents_server.logger") as mock_logger:
+            _warn_if_chat_llm_unconfigured()
+        assert mock_logger.warning.called
+
+    def test_does_not_raise_if_config_lookup_itself_fails(self):
+        with patch("common.llm.config.llm_config.get_model_config", side_effect=RuntimeError("boom")), \
+             patch("samples.start_agents_server.logger") as mock_logger:
+            _warn_if_chat_llm_unconfigured()
+        assert mock_logger.warning.called


### PR DESCRIPTION
## Description

Adds a `sample-agents` service to `docker-compose-dev.yml` (dev-only, layered on top of `docker-compose.yml` via `-f docker-compose.yml -f docker-compose-dev.yml`), running the sample A2A agent fleet in the same Compose stack as `orchestration-center`.

- `SAMPLE_AGENTS_HOST` makes the sample server advertise (and register) a Compose DNS name instead of the `127.0.0.1` hardcoded in `samples/agentcard/*.json`, which only resolves correctly when both processes share a host — containers don't.
- Binds agent servers to `0.0.0.0` when advertising a different host, while keeping same-host behavior unchanged when unset.
- Documents the duplicate-registration risk when a host-run `python -m samples.start_agents_server` and this container point at the same registry simultaneously.

Addresses two items from this feature's own submission checklist:

- **Unit tests for `_override_advertised_host()`** — no test file existed for `samples/start_agents_server.py` at all. Added `tests/test_start_agents_server.py` covering URL rewriting (port handling, multi-interface cards, missing url, no interfaces), including the odd-but-real behavior when `SAMPLE_AGENTS_HOST` itself carries a port.
- **Explicit health status when LLM configuration is missing** — negotiation-capable sample agents start fine without a configured chat LLM (`common/llm/config/llm_config.py` degrades rather than crashes) but every negotiation call then fails silently. `_warn_if_chat_llm_unconfigured()` surfaces that loudly at startup instead, reusing the missing-fields guard from #49.

Also fixed while validating: the port range in `docker-compose-dev.yml` (`8899-8907`) and a stale "11 cards" comment both referred to an older, larger sample-agent roster; the current fleet is 8 agents (ports `8899-8904` + `26335-26336`), tightened to match.

## Related Issue(s)

NA.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

Validated locally:
- `docker compose -f docker-compose.yml -f docker-compose-dev.yml config` — succeeds.
- `pytest tests/` (excluding the two live-HTTP integration files) — 315 passed, 7 pre-existing skips, 0 failures.
- `_override_advertised_host` and the new startup warning verified directly against real `a2a.types.AgentCard` instances, not just mocks.

Not validated (infra-dependent, out of scope for this sandbox): registration/discovery/an actual agent call end-to-end against a live registry-center, and registration behavior across container restarts. These need a running `registry-center` stack and real LLM credentials.