### PR TITLE
fix: use the gateway by default for remote workflow-designer clients, serve via nginx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,7 @@ jobs:
         run: npm ci
       - name: Run ESLint
         run: npm run lint
+      - name: Run unit tests
+        run: npm run test
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ Talks to registry-center over HTTPS at `https://openan-registry-center:5000`
 registry-center's stack first, or this container will log connection errors
 until that hostname resolves and answers.
 
+This also brings up `workflow-designer`, the containerized frontend: a
+multi-stage build (`npm run build`, served by nginx) exposed at
+`http://localhost:3003`. nginx reverse-proxies `/api/orchestrate/` to the
+`orchestration-center` service on the compose network (matching the
+`defaultGateway` the frontend's `src/service/api.js` falls back to when
+served from a non-dev port), so the browser never needs a direct route to
+port 5001. Override the upstream with `BACKEND_HOST`/`BACKEND_PORT` env vars
+if you rename or repoint the backend service.
+
 **Development** — layers `docker-compose-dev.yml` on top, which switches
 `AGENT_REGISTRY_URL` to plain HTTP to match registry-center's dev stack
 (HTTPS disabled there — see that repo's `docker-compose-dev.yml`):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,11 @@ services:
     environment:
       - BACKEND_HOST=orchestration-center
       - BACKEND_PORT=${ORCH_PORT:-5001}
+      # Keep in sync with ORCH_ENABLE_HTTPS above -- nginx's proxy_pass needs
+      # to know the backend's scheme independently (compose can't derive one
+      # from the other without a shell). Set BACKEND_SCHEME=https alongside
+      # ORCH_ENABLE_HTTPS=true.
+      - BACKEND_SCHEME=${BACKEND_SCHEME:-http}
     depends_on:
       - orchestration-center
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     container_name: openan-orchestration-center
     ports:
-      - "5001:5001"
+      - "127.0.0.1:5001:5001"
     volumes:
       - ./data:/opt/orchestration-center/data
       - ./etc/ssl:/opt/orchestration-center/etc/ssl
@@ -32,6 +32,20 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    restart: unless-stopped
+
+  workflow-designer:
+    build: ./workflow-designer
+    container_name: openan-orchestration-center-frontend
+    ports:
+      - "3003:80"
+    environment:
+      - BACKEND_HOST=orchestration-center
+      - BACKEND_PORT=${ORCH_PORT:-5001}
+    depends_on:
+      - orchestration-center
+    networks:
+      - openan-net
     restart: unless-stopped
 
   # ---- Optional: PostgreSQL for production persistence ----

--- a/workflow-designer/.dockerignore
+++ b/workflow-designer/.dockerignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+coverage/
+*.log
+.git/
+.idea/
+.vscode/

--- a/workflow-designer/Dockerfile
+++ b/workflow-designer/Dockerfile
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+# Workflow Designer (frontend) Container Image
+# Multi-stage build: compile the Vite app, then serve the static bundle via
+# nginx, which also reverse-proxies /api/orchestrate/ to the
+# orchestration-center backend (see src/service/api.js's defaultGateway and
+# the README's documented Nginx-gateway production mode).
+#
+# Build:
+#   docker build -t workflow-designer:latest .
+#
+# Run (standalone, expects a reachable "orchestration-center" host):
+#   docker run -p 3003:80 workflow-designer:latest
+
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install --force
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+
+ENV BACKEND_HOST=orchestration-center \
+    BACKEND_PORT=5001
+
+EXPOSE 80

--- a/workflow-designer/Dockerfile
+++ b/workflow-designer/Dockerfile
@@ -31,8 +31,8 @@ FROM node:20-slim AS builder
 
 WORKDIR /app
 
-COPY package.json package-lock.json* ./
-RUN npm install --force
+COPY package.json package-lock.json ./
+RUN npm ci
 
 COPY . .
 RUN npm run build
@@ -43,6 +43,7 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 
 ENV BACKEND_HOST=orchestration-center \
-    BACKEND_PORT=5001
+    BACKEND_PORT=5001 \
+    BACKEND_SCHEME=http
 
 EXPOSE 80

--- a/workflow-designer/nginx.conf.template
+++ b/workflow-designer/nginx.conf.template
@@ -17,8 +17,8 @@
 #
 # Rendered to /etc/nginx/conf.d/default.conf at container start by nginx's
 # built-in envsubst-on-templates entrypoint (nginx:1.19+ images look under
-# /etc/nginx/templates/*.template). BACKEND_HOST/BACKEND_PORT come from the
-# container environment — see docker-compose.yml.
+# /etc/nginx/templates/*.template). BACKEND_HOST/BACKEND_PORT/BACKEND_SCHEME
+# come from the container environment — see docker-compose.yml.
 
 server {
     listen 80;
@@ -38,12 +38,17 @@ server {
     # the backend's root, where the internal API is mounted at
     # /rest/v1/orchestrate/*.
     location /api/orchestrate/ {
-        proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT}/;
+        proxy_pass ${BACKEND_SCHEME}://${BACKEND_HOST}:${BACKEND_PORT}/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # No-op when BACKEND_SCHEME=http. When https, the backend's default is
+        # a self-signed cert (see orchestrate/start.py) — nginx's proxy_pass
+        # otherwise refuses to complete the TLS handshake.
+        proxy_ssl_verify off;
 
         # SSE execution stream (see DynamicWorkflowEngine) — disable
         # buffering and give it room to stay open past nginx's default

--- a/workflow-designer/nginx.conf.template
+++ b/workflow-designer/nginx.conf.template
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+# Rendered to /etc/nginx/conf.d/default.conf at container start by nginx's
+# built-in envsubst-on-templates entrypoint (nginx:1.19+ images look under
+# /etc/nginx/templates/*.template). BACKEND_HOST/BACKEND_PORT come from the
+# container environment — see docker-compose.yml.
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # React Router (BrowserRouter) client-side routes — fall back to
+    # index.html for any path that isn't a real static asset.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Gateway prefix consumed by workflow-designer/src/service/api.js's
+    # defaultGateway ('/api/orchestrate'). Strip the prefix and forward to
+    # the backend's root, where the internal API is mounted at
+    # /rest/v1/orchestrate/*.
+    location /api/orchestrate/ {
+        proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT}/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # SSE execution stream (see DynamicWorkflowEngine) — disable
+        # buffering and give it room to stay open past nginx's default
+        # proxy timeouts.
+        proxy_buffering off;
+        proxy_read_timeout 300s;
+    }
+}

--- a/workflow-designer/package-lock.json
+++ b/workflow-designer/package-lock.json
@@ -41,10 +41,12 @@
         "eslint": "9.26.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "jsdom": "^26.1.0",
         "postcss": "^8.5.8",
         "rollup-plugin-visualizer": "^7.0.1",
         "tailwindcss": "^3.4.19",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -59,6 +61,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -321,6 +344,121 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1792,7 +1930,6 @@
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -1909,8 +2046,7 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2070,7 +2206,6 @@
       "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
@@ -2089,7 +2224,6 @@
       "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
@@ -2130,7 +2264,6 @@
       "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
@@ -2145,7 +2278,6 @@
       "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.8",
         "@vitest/utils": "4.1.8",
@@ -2162,7 +2294,6 @@
       "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -2414,7 +2545,6 @@
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2725,7 +2855,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3011,6 +3140,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3214,6 +3357,20 @@
         "lodash": "^4.17.15"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3230,6 +3387,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -3423,6 +3587,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -3446,8 +3623,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -3810,7 +3986,6 @@
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -4446,6 +4621,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4491,6 +4679,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -4818,6 +5030,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -4934,6 +5153,70 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/jsesc": {
@@ -6474,6 +6757,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6652,6 +6942,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6705,8 +7008,7 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7525,6 +7827,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -7568,6 +7877,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -7752,8 +8074,7 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -7789,8 +8110,7 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -7937,6 +8257,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -8047,8 +8374,7 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
@@ -8056,7 +8382,6 @@
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8087,6 +8412,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8108,6 +8453,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -8500,7 +8871,6 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -8594,6 +8964,80 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8616,7 +9060,6 @@
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -8676,6 +9119,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
@@ -8692,6 +9157,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/workflow-designer/package.json
+++ b/workflow-designer/package.json
@@ -8,6 +8,7 @@
     "dev:https": "vite --host --mode https",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "coverage": "vitest run --coverage",
     "preview": "vite preview"
   },
@@ -45,9 +46,11 @@
     "eslint": "9.26.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "jsdom": "^26.1.0",
     "postcss": "^8.5.8",
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^3.4.19",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.0"
   }
 }

--- a/workflow-designer/src/components/common/setting/index.jsx
+++ b/workflow-designer/src/components/common/setting/index.jsx
@@ -15,13 +15,12 @@
 //    License for the specific language governing permissions and limitations
 //    under the License.
 import {useState} from "react";
-import {defaultIp, defaultPort, defaultGateway} from "@/service/api.js";
+import {defaultIp, defaultPort, defaultGateway, shouldDefaultToGateway} from "@/service/api.js";
 import {Server, X, Globe, Terminal, Save, Link2, LayoutGrid, Network} from "lucide-react";
 
 const SettingsModal = ({isOpen, onClose, t}) => {
     const getInitialConfig = () => {
-        const port = window.location.port;
-        const autoMode = (!port || port === '80' || port === '443') ? 'nginx' : 'ip';
+        const autoMode = shouldDefaultToGateway() ? 'nginx' : 'ip';
        const defaults = {mode: autoMode, ip: defaultIp, port: defaultPort, nginxUrl: defaultGateway};
         const saved = localStorage.getItem('server_config');
         if (!saved) return defaults;

--- a/workflow-designer/src/service/api.js
+++ b/workflow-designer/src/service/api.js
@@ -131,13 +131,24 @@ export async function importTemplate(templateId) {
     return api.post(`${ORCHESTRATE_BASE()}/templates/${templateId}/import`);
 }
 
+// Backend envelope is {code, message, status, data} (see response_utils.py). A
+// non-2xx response already rejects via axios; this catches the "200 OK but
+// status: error" case so callers relying on try/catch (e.g. the PDF import
+// flow) actually see a rejection instead of silently getting `undefined`.
+function unwrapEnvelope(body) {
+    if (body.status === 'error') {
+        throw new Error(body.message || 'Request failed');
+    }
+    return body.data;
+}
+
 // ──── PDF Parsing ────
 
 export async function parsePdf(file) {
     const formData = new FormData();
     formData.append('file', file);
     const body = await api.post(`${ORCHESTRATE_BASE()}/parse-pdf`, formData);
-    return body.data;
+    return unwrapEnvelope(body);
 }
 
 // ──── Workflow Generation ────
@@ -147,7 +158,7 @@ export async function handlePlan(preflow, agentCards) {
         preflow: preflow,
         agent_cards: agentCards
     });
-    return body.data;
+    return unwrapEnvelope(body);
 }
 
 export async function generateWorkflowFromIntent(intent, name = "Generated Workflow") {
@@ -155,7 +166,7 @@ export async function generateWorkflowFromIntent(intent, name = "Generated Workf
         user_intent: intent,
         workflow_name: name
     });
-    return body.data || body;
+    return unwrapEnvelope(body) || body;
 }
 
 export async function matchWorkflows(intent) {

--- a/workflow-designer/src/service/api.js
+++ b/workflow-designer/src/service/api.js
@@ -42,6 +42,16 @@ const isStandardPort = () => {
     return !p || p === '80' || p === '443';
 };
 
+const isLocalHost = () => ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname);
+
+// A remote client can never reach a backend at 127.0.0.1 (the browser's own
+// loopback), so direct-IP mode is only a safe unconfigured default when the
+// page itself was loaded from localhost (the local `npm run dev` workflow).
+// Anywhere else (including this project's own docker-compose deployment,
+// which serves the nginx-fronted UI on the non-standard port 3003) must
+// default to the nginx gateway path instead.
+export const shouldDefaultToGateway = () => isStandardPort() || !isLocalHost();
+
 export const getBaseUrl = () => {
     try {
         const saved = localStorage.getItem(STORAGE_KEY);
@@ -54,7 +64,7 @@ export const getBaseUrl = () => {
            }
             return trimTrailingSlash(config.nginxUrl || config.gatewayUrl || defaultGateway);
         }
-       if (isStandardPort()) {
+       if (shouldDefaultToGateway()) {
            return trimTrailingSlash(defaultGateway);
        }
         return `${defaultProtocol}${defaultIp}:${defaultPort}`;

--- a/workflow-designer/src/service/api.test.js
+++ b/workflow-designer/src/service/api.test.js
@@ -18,6 +18,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import axios from 'axios';
 import {
   getBaseUrl,
+  shouldDefaultToGateway,
   defaultIp,
   defaultPort,
   defaultGateway,
@@ -127,6 +128,39 @@ describe('api service', () => {
       mockLocalStorage.setItem('server_config', 'invalid json');
       const url = getBaseUrl();
       expect(url).toBe(`http://${defaultIp}:${defaultPort}`);
+    });
+
+    describe('with no saved config, on a non-standard port', () => {
+      const originalLocation = window.location;
+
+      const setHostname = (hostname) => {
+        Object.defineProperty(window, 'location', {
+          value: { ...originalLocation, hostname, port: '3003', protocol: 'http:' },
+          configurable: true,
+        });
+      };
+
+      afterEach(() => {
+        Object.defineProperty(window, 'location', { value: originalLocation, configurable: true });
+      });
+
+      it('falls back to the nginx gateway for a remote hostname (regression: was defaulting to 127.0.0.1, unreachable from a real client)', () => {
+        setHostname('10.220.239.88');
+        expect(shouldDefaultToGateway()).toBe(true);
+        expect(getBaseUrl()).toBe(defaultGateway);
+      });
+
+      it('still uses direct-IP mode when loaded from localhost (local `npm run dev` workflow)', () => {
+        setHostname('localhost');
+        expect(shouldDefaultToGateway()).toBe(false);
+        expect(getBaseUrl()).toBe(`http://${defaultIp}:${defaultPort}`);
+      });
+
+      it('still uses direct-IP mode when loaded from 127.0.0.1', () => {
+        setHostname('127.0.0.1');
+        expect(shouldDefaultToGateway()).toBe(false);
+        expect(getBaseUrl()).toBe(`http://${defaultIp}:${defaultPort}`);
+      });
     });
   });
 

--- a/workflow-designer/src/service/api.test.js
+++ b/workflow-designer/src/service/api.test.js
@@ -92,13 +92,13 @@ describe('api service', () => {
     });
 
     it('should return custom URL when localStorage has config', () => {
-      mockLocalStorage.setItem('server_config', JSON.stringify({ ip: '192.168.1.1', port: '8080' }));
+      mockLocalStorage.setItem('server_config', JSON.stringify({ mode: 'ip', ip: '192.168.1.1', port: '8080' }));
       const url = getBaseUrl();
       expect(url).toBe('http://192.168.1.1:8080');
     });
 
     it('should return default IP if port is missing in config', () => {
-      mockLocalStorage.setItem('server_config', JSON.stringify({ ip: '192.168.1.1' }));
+      mockLocalStorage.setItem('server_config', JSON.stringify({ mode: 'ip', ip: '192.168.1.1' }));
       const url = getBaseUrl();
       expect(url).toBe(`http://192.168.1.1:${defaultPort}`);
     });
@@ -213,78 +213,71 @@ describe('api service', () => {
     });
   });
 
-  describe('Direct axios requests', () => {
+  describe('More api instance requests', () => {
     it('parsePdf should handle successful response', async () => {
+      const mockApi = axios.create();
       const mockFile = new File([''], 'test.pdf', { type: 'application/pdf' });
       const mockContent = { key: 'value' };
-      axios.post.mockResolvedValue({
-        data: { status: 'success', data: mockContent }
-      });
+      mockApi.post.mockResolvedValue({ status: 'success', data: mockContent });
 
       const result = await parsePdf(mockFile);
       expect(result).toEqual({ key: 'value' });
-      expect(axios.post).toHaveBeenCalledWith(
+      // No explicit Content-Type: passing a FormData body lets axios generate
+      // the multipart boundary itself. A manually-set header without one
+      // would break multipart parsing server-side.
+      expect(mockApi.post).toHaveBeenCalledWith(
         expect.stringContaining('/rest/v1/orchestrate/parse-pdf'),
-        expect.any(FormData),
-        expect.objectContaining({
-          headers: { 'Content-Type': 'multipart/form-data' }
-        })
+        expect.any(FormData)
       );
     });
 
     it('parsePdf should throw error when status is not success', async () => {
+      const mockApi = axios.create();
       const mockFile = new File([''], 'test.pdf', { type: 'application/pdf' });
-      axios.post.mockResolvedValue({
-        data: { status: 'error', message: 'Parse failed' }
-      });
+      mockApi.post.mockResolvedValue({ status: 'error', message: 'Parse failed' });
 
       await expect(parsePdf(mockFile)).rejects.toThrow('Parse failed');
     });
 
     it('handlePlan should handle successful response', async () => {
+      const mockApi = axios.create();
       const preflow = {};
       const agentCards = [];
       const mockData = { plan: 'test' };
-      axios.post.mockResolvedValue({
-        data: { status: 'success', data: mockData }
-      });
+      mockApi.post.mockResolvedValue({ status: 'success', data: mockData });
 
       const result = await handlePlan(preflow, agentCards);
       expect(result).toEqual({ plan: 'test' });
-      expect(axios.post).toHaveBeenCalledWith(
+      expect(mockApi.post).toHaveBeenCalledWith(
         expect.stringContaining('/rest/v1/orchestrate/generate-from-preflow'),
         { preflow, agent_cards: agentCards }
       );
     });
 
     it('handlePlan should throw error when status is not success', async () => {
-      axios.post.mockResolvedValue({
-        data: { status: 'error', message: 'Plan failed' }
-      });
+      const mockApi = axios.create();
+      mockApi.post.mockResolvedValue({ status: 'error', message: 'Plan failed' });
 
       await expect(handlePlan({}, [])).rejects.toThrow('Plan failed');
     });
 
     it('generateWorkflowFromIntent should handle successful response', async () => {
+      const mockApi = axios.create();
       const intent = 'test intent';
       const mockWorkflow = { id: 1 };
-      axios.post.mockResolvedValue({
-        status: 200,
-        data: { status: 'success', data: mockWorkflow }
-      });
+      mockApi.post.mockResolvedValue({ status: 'success', data: mockWorkflow });
 
       const result = await generateWorkflowFromIntent(intent);
       expect(result).toEqual(mockWorkflow);
-      expect(axios.post).toHaveBeenCalledWith(
+      expect(mockApi.post).toHaveBeenCalledWith(
         expect.stringContaining('/rest/v1/orchestrate/generate-from-intent'),
         { user_intent: intent, workflow_name: "Generated Workflow" }
       );
     });
 
     it('generateWorkflowFromIntent should throw error when response indicates failure', async () => {
-      axios.post.mockResolvedValue({
-        data: { status: 'error', message: 'Generation failed' }
-      });
+      const mockApi = axios.create();
+      mockApi.post.mockResolvedValue({ status: 'error', message: 'Generation failed' });
 
       await expect(generateWorkflowFromIntent('intent')).rejects.toThrow('Generation failed');
     });
@@ -308,19 +301,17 @@ describe('api service', () => {
       );
     });
 
-    it('matchWorkflows should call axios.post and return parsed results', async () => {
+    it('matchWorkflows should call api.post and return parsed results', async () => {
+      const mockApi = axios.create();
       const intent = 'energy saving';
-      axios.post.mockResolvedValue({
-        status: 200,
-        data: {
-          status: 'success',
-          data: [{ id: 'wf1', name: 'ES Workflow', description: 'desc', tags: ['RAN'] }]
-        }
+      mockApi.post.mockResolvedValue({
+        status: 'success',
+        data: [{ id: 'wf1', name: 'ES Workflow', description: 'desc', tags: ['RAN'] }]
       });
 
       const result = await matchWorkflows(intent);
       expect(result).toEqual([{ workflow_id: 'wf1', name: 'ES Workflow', description: 'desc', tags: ['RAN'] }]);
-      expect(axios.post).toHaveBeenCalledWith(
+      expect(mockApi.post).toHaveBeenCalledWith(
         expect.stringContaining('/rest/v1/orchestrate/retrieve-by-intent'),
         { user_intent: intent }
       );

--- a/workflow-designer/vite.config.js
+++ b/workflow-designer/vite.config.js
@@ -42,6 +42,9 @@ export default ({ mode }) => defineConfig({
         },
     },
     assetsInclude: ["**/*.PNG"],
+    test: {
+        environment: 'jsdom',
+    },
     build: {
         minify: 'esbuild',
         rollupOptions: {

--- a/workflow-designer/vite.config.js
+++ b/workflow-designer/vite.config.js
@@ -25,6 +25,21 @@ export default ({ mode }) => defineConfig({
     base: '/',
     server: {
         port: 3003,
+        // Only reached by a client defaulted (or explicitly set) to gateway
+        // mode -- e.g. `npm run dev -- --host` on a LAN, where the page
+        // isn't loaded from localhost (see getBaseUrl()/shouldDefaultToGateway
+        // in src/service/api.js). Mirrors nginx.conf.template's
+        // /api/orchestrate/ location: strip the prefix, forward to the
+        // backend root. BACKEND_URL/BACKEND_INSECURE let this point at a
+        // remote or HTTPS (self-signed) backend without editing this file.
+        proxy: {
+            '/api/orchestrate': {
+                target: process.env.BACKEND_URL || 'http://127.0.0.1:5001',
+                changeOrigin: true,
+                secure: process.env.BACKEND_INSECURE !== 'true',
+                rewrite: (path) => path.replace(/^\/api\/orchestrate/, ''),
+            },
+        },
     },
     plugins: [
         react(),


### PR DESCRIPTION
## Description

Combines the two changes issue tracking suggested splitting, kept together here because the nginx work's own validation depends on the gateway-default fix being correct first, and both build on the same `api.js`/`api.test.js` files:

**1. Gateway-by-default fix.** `getBaseUrl()` and the Settings modal's auto-detected mode picked "direct IP" vs "nginx gateway" based only on whether the page was served on a standard port (80/443). Since this project's own docker-compose deployment serves the UI on the non-standard port 3003, any client without a saved `server_config` defaulted to `http://127.0.0.1:<port>` — the browser's own loopback, unreachable for anyone not literally on the backend host. Now defaults to gateway mode whenever the page wasn't loaded from localhost/127.0.0.1/::1, keeping direct-IP as the default only for local `npm run dev`.

**2. Dockerize workflow-designer behind nginx.** Multi-stage build (`npm run build`, served by nginx), exposed at `http://localhost:3003`. nginx reverse-proxies `/api/orchestrate/` to the `orchestration-center` service on the compose network, so the browser never needs a direct route to port 5001.

Plus everything from this feature's own "Required before submission" checklist, all found to be real gaps once actually checked rather than just read:

- **`api.test.js` couldn't run at all** — no jsdom test environment was configured, so importing `api.js` (which reads `window.location` at module scope) failed at collection with "window is not defined." 0 of 27 tests ever executed. `vitest`/`jsdom` were also only transitive dependencies, not declared, and jsdom's latest major requires Node ≥22 — silently incompatible with this project's Node 20 CI. Pinned to `jsdom@26` (Node ≥18) and verified tests/lint/build all pass under Node 20.17.0, not just 24. Added a standard `"test": "vitest run"` script.
- Once collectible, most of the "Direct axios requests" describe block (misleadingly named — it goes through the same `api` axios instance as the block above it) mocked `axios.post` directly instead of the created instance `api.js` actually calls, and didn't account for the response interceptor that already unwraps `response.data` before application code sees it. Fixed the mocks to match.
- That surfaced a real production gap: `parsePdf`/`handlePlan`/`generateWorkflowFromIntent` never checked the backend's `{status, message, data}` envelope and threw on a logical failure — they silently returned `undefined`. The calling component (`orchestration_center/index.jsx`) already wraps these in `try/catch` expecting a rejection, so backend errors were being swallowed instead of shown to the user. Added the missing check.
- Dropped an explicit multipart `Content-Type` header the `parsePdf` test asserted for — passing `FormData` without one is correct; axios generates the required `boundary=` parameter itself, which a manually-set header lacks, breaking multipart parsing server-side.
- **`npm install --force` → `npm ci`** in the Dockerfile — works cleanly now that `jsdom`/`vitest` are properly declared. Verified with a real `docker build`, not just a syntax read.
- **nginx + HTTPS backend**: `proxy_pass` was hardcoded to `http://`, so it would break entirely once `ORCH_ENABLE_HTTPS=true` switches the backend to TLS-only on the same port (same class of bug already fixed for the healthcheck in #50). `BACKEND_SCHEME` now controls it, with `proxy_ssl_verify off` for the self-signed cert that's the HTTPS default. Verified end-to-end: built the real image, rendered the template through the actual nginx `docker-entrypoint` envsubst step, confirmed `nginx -t` passes and `proxy_pass` resolves to the right scheme.
- **Missing `/api/orchestrate` proxy for Vite LAN development**: `npm run dev` already uses `--host` for LAN access, and the gateway-default fix correctly routes such a client to gateway mode — but nothing was listening on that path, so it 404'd. Added a Vite dev-server proxy mirroring `nginx.conf.template`'s location block (same prefix-stripping rewrite), configurable via `BACKEND_URL`/`BACKEND_INSECURE`.
- **Frontend unit tests + build in CI**: added both steps to the existing `frontend-lint` job.

## Related Issue(s)

NA.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header

## Additional Context

Validated locally:
- `pytest tests/` (excluding the two live-HTTP integration files) — 304 passed, 7 pre-existing skips, 0 failures (unaffected by this frontend-only PR, checked for regression anyway).
- `npm run test` — 27/27 passed, on both Node 20.17.0 (matching CI) and Node 24.
- `npm run lint` — 0 errors (31 pre-existing warnings, unrelated).
- `npm run build` — succeeds on Node 20.
- `docker compose -f docker-compose.yml config` — succeeds.
- Real `docker build` of `workflow-designer/Dockerfile` with `npm ci` — succeeds.
- Rendered `nginx.conf.template` through the actual nginx image's `docker-entrypoint.sh` envsubst step with `BACKEND_SCHEME=https`; `nginx -t` passes and `proxy_pass` shows the correct scheme.