### PR TITLE
fix: require admin role on /auth/users list and delete

### DIFF
--- a/orchestrate/server/auth.py
+++ b/orchestrate/server/auth.py
@@ -31,7 +31,7 @@ import secrets
 import threading
 import time
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 from loguru import logger
 from starlette import status
 from starlette.responses import JSONResponse
@@ -83,19 +83,24 @@ class _SessionStore:
     """Thread-safe in-memory token store with TTL."""
 
     def __init__(self):
-        # token -> (username, expiry epoch)
-        self._tokens: dict[str, tuple[str, float]] = {}
+        # token -> (username, role, expiry epoch)
+        self._tokens: dict[str, tuple[str, str, float]] = {}
         self._lock = threading.Lock()
 
-    def create(self, username: str) -> tuple[str, int]:
-        """Create a new session token for the given user."""
+    def create(self, username: str, role: str = "user") -> tuple[str, int]:
+        """Create a new session token for the given user and role.
+
+        ``role`` is stamped once at login rather than re-resolved per
+        request, so admin-only checks don't add a DB lookup to every
+        authenticated request.
+        """
         token = secrets.token_urlsafe(32)
         ttl = _get_ttl()
         expiry = time.time() + ttl
         with self._lock:
             self._cleanup_locked()
-            self._tokens[token] = (username, expiry)
-        logger.info(f"Session token created for user '{username}', expires in {ttl}s")
+            self._tokens[token] = (username, role, expiry)
+        logger.info(f"Session token created for user '{username}' (role={role}), expires in {ttl}s")
         return token, ttl
 
     def validate(self, token: str) -> bool:
@@ -107,7 +112,7 @@ class _SessionStore:
             entry = self._tokens.get(token)
             if entry is None:
                 return False
-            if now >= entry[1]:
+            if now >= entry[2]:
                 del self._tokens[token]
                 return False
             return True
@@ -119,10 +124,22 @@ class _SessionStore:
         now = time.time()
         with self._lock:
             entry = self._tokens.get(token)
-            if entry is None or now >= entry[1]:
+            if entry is None or now >= entry[2]:
                 self._tokens.pop(token, None)
                 return None
             return entry[0]
+
+    def get_role(self, token: str) -> str | None:
+        """Return the role associated with the token, or None."""
+        if not token:
+            return None
+        now = time.time()
+        with self._lock:
+            entry = self._tokens.get(token)
+            if entry is None or now >= entry[2]:
+                self._tokens.pop(token, None)
+                return None
+            return entry[1]
 
     def revoke(self, token: str) -> None:
         with self._lock:
@@ -131,7 +148,7 @@ class _SessionStore:
     def _cleanup_locked(self) -> None:
         """Remove expired tokens (caller must hold the lock)."""
         now = time.time()
-        expired = [t for t, (_, exp) in self._tokens.items() if now >= exp]
+        expired = [t for t, (_, _, exp) in self._tokens.items() if now >= exp]
         for t in expired:
             del self._tokens[t]
 
@@ -150,6 +167,21 @@ def _extract_token(request: Request) -> str | None:
     if auth_header.startswith("Bearer "):
         return auth_header[7:].strip()
     return request.query_params.get("access_token")
+
+
+def require_admin(request: Request) -> None:
+    """FastAPI dependency: reject the request unless the session role is 'admin'.
+
+    No-op when auth is disabled: ``auth_middleware`` already lets every
+    request through in that mode, so re-checking here would just lock
+    everyone out of a deployment that has authentication turned off.
+    """
+    if not is_auth_enabled():
+        return
+    token = _extract_token(request)
+    role = _session_store.get_role(token) if token else None
+    if role != "admin":
+        raise HTTPException(status_code=403, detail="Admin role required")
 
 
 async def auth_middleware(request: Request, call_next):

--- a/orchestrate/server/frontend_support_server.py
+++ b/orchestrate/server/frontend_support_server.py
@@ -64,6 +64,7 @@ from orchestrate.server.auth import (
     is_auth_enabled,
     get_session_store,
     auth_middleware,
+    require_admin,
 )
 
 app = FastAPI(title="Workflow Orchestration API", version="1.0.0", docs_url=None, redoc_url=None, openapi_url=None)
@@ -205,15 +206,16 @@ async def login(request: LoginRequest):
         from database.utils.user_store import authenticate_user
         user = authenticate_user(request.username, request.password)
         if user is not None:
-            token, ttl = get_session_store().create(user["username"])
+            role = user.get("role", "user")
+            token, ttl = get_session_store().create(user["username"], role)
             logger.info(f"Login successful (DB): {user['username']}")
-            return ok(data={"auth_required": True, "token": token, "expires_in": ttl, "username": user["username"], "role": user.get("role", "user")})
+            return ok(data={"auth_required": True, "token": token, "expires_in": ttl, "username": user["username"], "role": role})
         logger.warning(f"Login failed: username={request.username}")
         raise HTTPException(status_code=401, detail="Incorrect username or password")
     # File mode: config-based auth
     stored = conf.get("access_password", "")
     if request.username == "admin" and stored and secrets.compare_digest(request.password, stored):
-        token, ttl = get_session_store().create("admin")
+        token, ttl = get_session_store().create("admin", "admin")
         logger.info("Login successful (config): admin")
         return ok(data={"auth_required": True, "token": token, "expires_in": ttl, "username": "admin", "role": "admin"})
     logger.warning(f"Login failed: username={request.username}")
@@ -256,12 +258,12 @@ async def auth_check(request: Request):
     return ok(data={"auth_required": True, "authenticated": False, "registration_enabled": registration_enabled})
 
 @router.get("/auth/users")
-async def list_users_endpoint():
+async def list_users_endpoint(_: Any = Depends(require_admin)):
     from database.utils.user_store import list_users
     return ok(data=list_users())
 
 @router.delete("/auth/users/{username}")
-async def delete_user_endpoint(username: str):
+async def delete_user_endpoint(username: str, _: Any = Depends(require_admin)):
     if username == "admin":
         raise HTTPException(status_code=403, detail="Cannot delete admin user")
     from database.utils.user_store import delete_user

--- a/tests/test_auth_admin_gate.py
+++ b/tests/test_auth_admin_gate.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+
+import pytest
+from fastapi import HTTPException, Request
+
+from orchestrate.server import auth as auth_module
+from orchestrate.server.auth import _SessionStore, require_admin
+
+
+def _make_request(token: str | None = None, as_query_param: bool = False) -> Request:
+    headers = []
+    query_string = b""
+    if token:
+        if as_query_param:
+            query_string = f"access_token={token}".encode()
+        else:
+            headers.append((b"authorization", f"Bearer {token}".encode()))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/rest/v1/orchestrate/auth/users",
+        "headers": headers,
+        "query_string": query_string,
+    }
+    return Request(scope)
+
+
+class TestSessionStoreRole:
+    def test_create_stores_role(self):
+        store = _SessionStore()
+        token, _ = store.create("alice", "admin")
+        assert store.get_role(token) == "admin"
+
+    def test_default_role_is_user(self):
+        store = _SessionStore()
+        token, _ = store.create("bob")
+        assert store.get_role(token) == "user"
+
+    def test_get_role_unknown_token(self):
+        store = _SessionStore()
+        assert store.get_role("does-not-exist") is None
+
+    def test_get_role_expired_token(self):
+        store = _SessionStore()
+        token, _ = store.create("carol", "admin")
+        username, role, _ = store._tokens[token]
+        store._tokens[token] = (username, role, time.time() - 1)
+        assert store.get_role(token) is None
+        # Expired lookups also evict the entry.
+        assert token not in store._tokens
+
+
+class TestRequireAdmin:
+    """Regression coverage for #7: admin-only gate on /auth/users*."""
+
+    def test_admin_token_passes(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        store = auth_module.get_session_store()
+        token, _ = store.create("admin_user", "admin")
+        try:
+            require_admin(_make_request(token))  # must not raise
+        finally:
+            store.revoke(token)
+
+    def test_non_admin_token_rejected(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        store = auth_module.get_session_store()
+        token, _ = store.create("regular_user", "user")
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                require_admin(_make_request(token))
+            assert exc_info.value.status_code == 403
+        finally:
+            store.revoke(token)
+
+    def test_missing_token_rejected(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin(_make_request(None))
+        assert exc_info.value.status_code == 403
+
+    def test_invalid_token_rejected(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin(_make_request("not-a-real-token"))
+        assert exc_info.value.status_code == 403
+
+    def test_noop_when_auth_disabled(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: False)
+        require_admin(_make_request(None))  # must not raise


### PR DESCRIPTION
## Description

`POST /auth/register` is public (`_PUBLIC_AUTH_PATHS`) and only ever creates a `"user"`-role account with no way to self-escalate. But `GET /auth/users` and `DELETE /auth/users/{username}` only required *any* valid session token via the generic `auth_middleware` — there was no role check. The `users.role` column was written on account creation but never read or enforced anywhere.

Exploit chain this closes: anonymous visitor registers → logs in → enumerates every username via `/auth/users` → deletes any non-admin account via `DELETE /auth/users/{username}`.

## What changed

- `_SessionStore.create()` now takes a `role` (stamped once at login) and exposes `get_role(token)`. Role is resolved once, at login, rather than per request — `is_auth_enabled()` already does a DB round-trip on every request in `persistence_mode=postgresql` (`has_any_user()`), and re-resolving role from the DB on every `/auth/users` call would have added a second one to the same hot path.
- New `require_admin` FastAPI dependency in `orchestrate/server/auth.py`, gating both `GET /auth/users` and `DELETE /auth/users/{username}`. It's a no-op when auth is disabled, since `auth_middleware` already admits every request in that mode — re-checking there would just lock everyone out of a deployment that has authentication turned off by design.
- `login()` now passes the authenticated user's `role` into `get_session_store().create(...)` for both DB mode (reads `role` from `authenticate_user()`) and file mode (always `"admin"`, matching existing single-admin file-mode behavior).

## Deliberately out of scope

`/auth/register` stays public. A self-registered `"user"`-role account still gets access to the rest of the internal API (workflow CRUD, PDF parsing, LLM-backed generation, SSE execution) once logged in — that's treated as intended multi-user behavior for this deployment model (anyone who can reach the instance can use it), not a vulnerability. The vulnerability was specifically the ability to enumerate and delete *other users'* accounts, which this PR closes. Reconsidering whether registration itself should require an invite/approval step is a separate product decision, not folded in here.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

Validated locally: `pytest tests/ --ignore=tests/test_external_apis.py` — 339 passed, 7 pre-existing skips, 0 failures (330 baseline + 9 new in `tests/test_auth_admin_gate.py`).

New tests cover: role is stamped and retrievable via the session store, expired-token role lookup evicts and returns `None`, an admin token passes `require_admin`, a non-admin token is rejected with 403, a missing/invalid token is rejected with 403, and the dependency is a no-op when auth is disabled.

This is one of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37 (the shared security implementation is byte-identical to what's already merged upstream, so these are new forward fixes, not cherry-picks). Landing this one first and independently, since 5 of its 7 sibling issues also touch `orchestrate/server/frontend_support_server.py`'s `login()`/auth routes.
