### PR TITLE
fix: rate-limit /auth/login separately from every other endpoint

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -52,3 +52,7 @@ FLOW_CTL_PARALLEL_RETRIEVE_PSOP = "flowcontrol.parallelism.retrieve_psop"
 
 FLOW_CTL_START_PROCESS_STREAM = "flowcontrol.ratelimit.start_process_stream"
 FLOW_CTL_PARALLEL_START_PROCESS_STREAM = "flowcontrol.parallelism.start_process_stream"
+
+# Login has no parallelism counterpart: it's throttled per-minute per client,
+# not capped on concurrency like the endpoints above.
+FLOW_CTL_LOGIN = "flowcontrol.ratelimit.login"

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -80,3 +80,7 @@ flowcontrol.parallelism.retrieve_psop=50
 # Execute workflow (SSE streaming)
 flowcontrol.ratelimit.start_process_stream=50
 flowcontrol.parallelism.start_process_stream=50
+
+# Login (requests per minute, not per second -- credential-guessing surface,
+# throttled much stricter than the endpoints above).
+flowcontrol.ratelimit.login=5

--- a/orchestrate/server/frontend_support_server.py
+++ b/orchestrate/server/frontend_support_server.py
@@ -57,7 +57,7 @@ from orchestrate.server.external_api import router as external_router
 from orchestrate.core.psop_generator import PsopGenerator
 from orchestrate.core.intent_psop_generator import IntentPsopGenerator
 from orchestrate.core.workflow_search_result import WorkflowSearchResult
-from orchestrate.server.middleware import ConnectionLimitMiddleware, TimeoutMiddleware, RateLimiter
+from orchestrate.server.middleware import ConnectionLimitMiddleware, TimeoutMiddleware, RateLimiter, LoginRateLimiter
 from orchestrate.server.shared_handlers import SharedHandlers
 from orchestrate.solution_package.parse_flow import SolutionPackageParser
 from orchestrate.server.auth import (
@@ -196,7 +196,7 @@ class RegisterRequest(BaseModel):
     password: str = Field(..., min_length=6, max_length=256, description="Password (SHA-256 hashed by frontend)")
 
 @router.post("/auth/login")
-async def login(request: LoginRequest):
+async def login(request: LoginRequest, _: Any = Depends(LoginRateLimiter(config))):
     if not is_auth_enabled():
         return ok(data={"auth_required": False, "token": None}, message="Authentication disabled")
     conf = get_conf()

--- a/orchestrate/server/middleware.py
+++ b/orchestrate/server/middleware.py
@@ -28,6 +28,7 @@ from common.config import (
     FLOW_CTL_PARSE_PDF, FLOW_CTL_PLAN, FLOW_CTL_ALL_PSOPS, FLOW_CTL_ONE_PSOP,
     FLOW_CTL_SAVE_PSOP, FLOW_CTL_DELETE_PSOP, FLOW_CTL_AGENT_CARDS,
     FLOW_CTL_GENERATE_PSOP, FLOW_CTL_RETRIEVE_PSOP, FLOW_CTL_START_PROCESS_STREAM,
+    FLOW_CTL_LOGIN,
 )
 from common.util.config_util import get_conf
 
@@ -156,6 +157,35 @@ class RateLimiter:
         self.rate_item = parse_rate_limit(interface_name, config)
         if not self.rate_item:
             raise ValueError("Invalid rate limit configuration")
+
+    async def __call__(self, request: Request):
+        identifier = request.client.host if request.client else "unknown"
+        if not await async_hit(self.rate_item, identifier):
+            raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many requests")
+        return True
+
+
+class LoginRateLimiter:
+    """Per-minute rate limit for /auth/login, keyed by client IP.
+
+    RateLimiter's X/second granularity (50/second by default) is far too
+    permissive for a credential-guessing endpoint -- it would still allow
+    thousands of login attempts per minute. Login is throttled by minute
+    instead, sharing the same moving-window limiter/storage as RateLimiter.
+    """
+
+    _DEFAULT_PER_MINUTE = 5
+
+    def __init__(self, config):
+        try:
+            rate_value = int(config.get(FLOW_CTL_LOGIN, self._DEFAULT_PER_MINUTE))
+        except (ValueError, TypeError):
+            logger.error(f"Config key '{FLOW_CTL_LOGIN}' has invalid value, using default {self._DEFAULT_PER_MINUTE}")
+            rate_value = self._DEFAULT_PER_MINUTE
+        items = parse_many(f"{rate_value}/minute")
+        if not items:
+            raise ValueError("Invalid rate limit configuration")
+        self.rate_item = items[0]
 
     async def __call__(self, request: Request):
         identifier = request.client.host if request.client else "unknown"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -21,7 +21,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from orchestrate.server.middleware import (
-    parse_rate_limit, RateLimiter, async_hit,
+    parse_rate_limit, RateLimiter, LoginRateLimiter, async_hit,
     ConnectionLimitMiddleware, TimeoutMiddleware
 )
 from fastapi import Request, HTTPException
@@ -84,6 +84,57 @@ class TestRateLimiter:
         with patch('orchestrate.server.middleware.parse_rate_limit', return_value=None):
             with pytest.raises(ValueError, match="Invalid rate limit configuration"):
                 RateLimiter({}, "nonexistent")
+
+
+class TestLoginRateLimiter:
+    """Regression coverage for #8: /auth/login has its own, much stricter,
+    per-minute rate limit instead of RateLimiter's X/second granularity."""
+
+    def _make_request(self, host="127.0.0.1"):
+        mock_request = MagicMock(spec=Request)
+        mock_request.client.host = host
+        return mock_request
+
+    def test_default_rate_is_five_per_minute(self):
+        limiter = LoginRateLimiter({})
+        assert str(limiter.rate_item) == "5 per 1 minute"
+
+    def test_uses_configured_value(self):
+        limiter = LoginRateLimiter({"flowcontrol.ratelimit.login": "3"})
+        assert str(limiter.rate_item) == "3 per 1 minute"
+
+    def test_uses_default_when_config_invalid(self):
+        limiter = LoginRateLimiter({"flowcontrol.ratelimit.login": "not_a_number"})
+        assert str(limiter.rate_item) == "5 per 1 minute"
+
+    @pytest.mark.anyio
+    async def test_allows_within_limit(self):
+        limiter = LoginRateLimiter({"flowcontrol.ratelimit.login": "5"})
+        request = self._make_request(host="203.0.113.1")
+        for _ in range(5):
+            assert await limiter(request) is True
+
+    @pytest.mark.anyio
+    async def test_rejects_once_limit_exceeded(self):
+        limiter = LoginRateLimiter({"flowcontrol.ratelimit.login": "2"})
+        request = self._make_request(host="203.0.113.2")
+        assert await limiter(request) is True
+        assert await limiter(request) is True
+        with pytest.raises(HTTPException) as exc_info:
+            await limiter(request)
+        assert exc_info.value.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    @pytest.mark.anyio
+    async def test_limit_is_per_client(self):
+        limiter = LoginRateLimiter({"flowcontrol.ratelimit.login": "1"})
+        assert await limiter(self._make_request(host="203.0.113.3")) is True
+        # A different client IP has its own, unaffected budget.
+        assert await limiter(self._make_request(host="203.0.113.4")) is True
+
+    def test_raises_for_unparseable_rate_string(self):
+        with patch('orchestrate.server.middleware.parse_many', return_value=[]):
+            with pytest.raises(ValueError, match="Invalid rate limit configuration"):
+                LoginRateLimiter({})
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

Unlike every other endpoint in `orchestrate/server/frontend_support_server.py`, `POST /auth/login` had no `Depends(RateLimiter(...))` and no lockout/backoff of any kind. The only protections in front of it were `ConnectionLimitMiddleware`/`TimeoutMiddleware`, which cap total concurrent connections, not repeated attempts from a single client. Combined with a fast-to-compute client-side SHA-256 credential (`api.js` hashes the password before sending), this left the endpoint open to an unthrottled dictionary attack — including against the shipped default `admin`/`OpenAN@2026` credentials in `persistence_mode=postgresql` before an operator changes them.

## What changed

`RateLimiter`'s granularity is X/second (50/second by default) — reused as-is, that's still ~3000 attempts/minute, far too permissive for a credential-guessing surface. Added a dedicated `LoginRateLimiter` in `orchestrate/server/middleware.py` that throttles by **minute** instead, sharing the same moving-window limiter/storage backend as `RateLimiter`, keyed by client IP:

- Defaults to **5 attempts/minute per client IP**, configurable via the new `flowcontrol.ratelimit.login` key (added to `etc/conf/server.properties`, default `5`).
- Wired into `POST /auth/login` via `Depends(LoginRateLimiter(config))`, matching the existing `Depends(RateLimiter(config, "..."))` pattern used everywhere else in this file.
- Exceeding the limit returns `429 Too Many Requests`, same as the existing `RateLimiter`.

## Deliberately out of scope

- **SHA-256 hash speed / offline cracking of a stolen `users` table** — that's a different mechanic (offline, not rate-limitable) and belongs to hw-irc-sni/orchestration-center#9.
- **Removing the known default credential itself** — tracked separately in hw-irc-sni/orchestration-center#12. This PR and #12 are complementary: #12 removes the known password, this PR removes the unthrottled guessing channel. Fixing either alone leaves the other's attack viable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed (config comment in `server.properties`)
- [x] New source files include the SPDX license header

## Additional Context

Validated locally: `pytest tests/ --ignore=tests/test_external_apis.py` — 337 passed, 7 pre-existing skips, 0 failures. 8 new tests in `tests/test_middleware.py::TestLoginRateLimiter` cover: default/configured/invalid-config rate values, allowing requests within the limit, rejecting with 429 once exceeded, per-client isolation (one client's exhausted budget doesn't affect another), and the `ValueError` guard when the rate string can't be parsed.

One of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37. Second in the recommended sequence, after #7 (hw-irc-sni/orchestration-center#7 → project-openan/orchestration-center#56, not yet merged) — this PR does not depend on it and applies cleanly against `main` independently.
