### PR TITLE
fix: make file-mode change-password atomic and serialized

### DIFF
--- a/orchestrate/server/frontend_support_server.py
+++ b/orchestrate/server/frontend_support_server.py
@@ -18,6 +18,7 @@
 import os
 import secrets
 import tempfile
+import threading
 import json
 import re
 import pathlib
@@ -275,6 +276,38 @@ class ChangePasswordRequest(BaseModel):
     old_password: str = Field(..., min_length=1, max_length=256, description="Current password (SHA-256 hashed)")
     new_password: str = Field(..., min_length=6, max_length=256, description="New password (SHA-256 hashed)")
 
+# Serializes file-mode password changes and makes the server.conf rewrite
+# below atomic (temp file + os.replace instead of truncate-in-place), so a
+# crash or full disk mid-write can never leave a truncated config file.
+_password_file_lock = threading.Lock()
+
+
+def _update_access_password_in_conf(conf_path: str, new_password: str) -> bool:
+    """Rewrite the access_password= line in server.conf. Returns False (no
+    write performed) if the key isn't present in the file."""
+    with _password_file_lock:
+        with open(conf_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+        updated = False
+        for i, line in enumerate(lines):
+            if line.strip().startswith("access_password="):
+                lines[i] = f"access_password={new_password}\n"
+                updated = True
+                break
+        if not updated:
+            return False
+        conf_dir = os.path.dirname(conf_path)
+        fd, tmp_path = tempfile.mkstemp(dir=conf_dir, prefix=".server.conf.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.writelines(lines)
+            os.replace(tmp_path, conf_path)
+        except BaseException:
+            os.unlink(tmp_path)
+            raise
+        get_conf.cache_clear()
+        return True
+
 @router.post("/auth/change-password")
 async def change_password(request: ChangePasswordRequest, http_request: Request):
     """Change the current user's password. Requires a valid token."""
@@ -299,25 +332,15 @@ async def change_password(request: ChangePasswordRequest, http_request: Request)
     stored = conf.get("access_password", "")
     if not secrets.compare_digest(request.old_password, stored):
         raise HTTPException(status_code=401, detail="Current password is incorrect")
-    # Write new password hash to server.conf
     conf_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "etc", "conf", "server.conf")
-    if os.path.exists(conf_path):
-        with open(conf_path, "r", encoding="utf-8") as f:
-            lines = f.readlines()
-        updated = False
-        for i, line in enumerate(lines):
-            if line.strip().startswith("access_password="):
-                lines[i] = f"access_password={request.new_password}\n"
-                updated = True
-                break
-        if updated:
-            with open(conf_path, "w", encoding="utf-8") as f:
-                f.writelines(lines)
-            # Invalidate the config cache
-            get_conf.cache_clear()
-            logger.info("Password changed (file mode): access_password updated in server.conf")
-            return ok(message="Password changed successfully")
-    raise HTTPException(status_code=500, detail="Failed to change password")
+    if not os.path.exists(conf_path):
+        logger.error(f"Cannot change password: {conf_path} does not exist")
+        raise HTTPException(status_code=500, detail="server.conf not found")
+    if _update_access_password_in_conf(conf_path, request.new_password):
+        logger.info("Password changed (file mode): access_password updated in server.conf")
+        return ok(message="Password changed successfully")
+    logger.error(f"Cannot change password: no access_password key in {conf_path}")
+    raise HTTPException(status_code=500, detail="access_password key not found in server.conf")
 
 # Workflow CRUD
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_change_password_atomic.py
+++ b/tests/test_change_password_atomic.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+import threading
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("TESTING", "True")
+
+from orchestrate.server.frontend_support_server import _update_access_password_in_conf
+
+
+CONF_TEMPLATE = """ip=127.0.0.1
+port=5001
+enable_https=false
+access_password={password}
+persistence_mode=file
+"""
+
+
+@pytest.fixture
+def conf_file(tmp_path):
+    path = tmp_path / "server.conf"
+    path.write_text(CONF_TEMPLATE.format(password="old-hash"), encoding="utf-8")
+    return path
+
+
+class TestUpdateAccessPasswordInConf:
+    """Regression coverage for #13: atomic, serialized server.conf rewrite."""
+
+    def test_updates_access_password_line(self, conf_file):
+        assert _update_access_password_in_conf(str(conf_file), "new-hash") is True
+        content = conf_file.read_text(encoding="utf-8")
+        assert "access_password=new-hash\n" in content
+        # Every other line and the line count are preserved.
+        assert "ip=127.0.0.1\n" in content
+        assert "persistence_mode=file\n" in content
+        assert content.count("\n") == CONF_TEMPLATE.count("\n")
+
+    def test_returns_false_when_key_missing(self, tmp_path):
+        path = tmp_path / "server.conf"
+        path.write_text("ip=127.0.0.1\nport=5001\n", encoding="utf-8")
+        assert _update_access_password_in_conf(str(path), "new-hash") is False
+        # Untouched: no key to rewrite, so nothing should have been written.
+        assert path.read_text(encoding="utf-8") == "ip=127.0.0.1\nport=5001\n"
+
+    def test_no_temp_file_left_behind_on_success(self, conf_file):
+        _update_access_password_in_conf(str(conf_file), "new-hash")
+        leftovers = [p for p in conf_file.parent.iterdir() if p.name != "server.conf"]
+        assert leftovers == []
+
+    def test_original_file_untouched_and_temp_cleaned_up_on_write_failure(self, conf_file):
+        original = conf_file.read_text(encoding="utf-8")
+        with patch("os.replace", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                _update_access_password_in_conf(str(conf_file), "new-hash")
+        # os.replace never ran: the original file is exactly as it was before.
+        assert conf_file.read_text(encoding="utf-8") == original
+        leftovers = [p for p in conf_file.parent.iterdir() if p.name != "server.conf"]
+        assert leftovers == []
+
+    def test_concurrent_writers_are_serialized_not_interleaved(self, conf_file):
+        """Two racing writers must never interleave into a corrupted file --
+        the lock should serialize them, leaving exactly one well-formed
+        access_password= line with one of the two candidate values."""
+        results = []
+
+        def _write(password):
+            results.append(_update_access_password_in_conf(str(conf_file), password))
+
+        t1 = threading.Thread(target=_write, args=("password-a",))
+        t2 = threading.Thread(target=_write, args=("password-b",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert results == [True, True]
+        content = conf_file.read_text(encoding="utf-8")
+        access_password_lines = [l for l in content.splitlines() if l.startswith("access_password=")]
+        assert len(access_password_lines) == 1
+        assert access_password_lines[0] in ("access_password=password-a", "access_password=password-b")
+        assert content.count("\n") == CONF_TEMPLATE.count("\n")


### PR DESCRIPTION
## Description

The file-mode branch of `POST /auth/change-password` rewrote `etc/conf/server.conf` with a plain read-modify-write: read the whole file, patch the `access_password=` line in memory, then `open(conf_path, "w")` — which truncates the file before `writelines()` runs. A crash, `SIGKILL`, or `ENOSPC` between truncate and flush left a **truncated `server.conf` behind**, carrying every other setting this file holds (`ip`, `port`, `enable_https`, all `ssl_*` paths, `persistence_mode`, `agent_registry_url`, `forwarded_allow_ips`), not just the password. There was also no locking around the sequence, so two concurrent `change-password` calls could interleave.

## What changed

`_update_access_password_in_conf()` replaces the inline read-modify-write in `change_password()`:

- Serializes the whole operation behind a module-level `threading.Lock`.
- Writes via a temp file in the same directory (`tempfile.mkstemp(dir=conf_dir, ...)`) followed by `os.replace()`, so a failure mid-write can never leave `server.conf` partially written — the original file is untouched until the replace succeeds, and the temp file is cleaned up on any exception.
- Makes the "`access_password` key not present in the file" path explicit — its own log line and error detail — instead of falling through to the same generic 500 as a missing conf file entirely.

Landing this while the file-mode credential path still exists in its current form, since hw-irc-sni/orchestration-center#9 is expected to restructure or remove it — the fix would be wasted effort once that lands.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

Validated locally: `pytest tests/ --ignore=tests/test_external_apis.py` — 335 passed, 7 pre-existing skips, 0 failures. 5 new tests in `tests/test_change_password_atomic.py` cover: successful rewrite preserves every other line, missing-key returns `False` without touching the file, no temp file left behind on success, original file untouched and temp file cleaned up when `os.replace()` fails mid-write, and two concurrent writers are serialized into a single well-formed line rather than interleaved/corrupted.

One of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37. Third in the recommended sequence (#7 → #8 → #13 → #12 → #14 → #9 → #16) — chosen to land early specifically because #9 will later touch this same code path. Independent of #7 (project-openan/orchestration-center#56) and #8 (project-openan/orchestration-center#57); applies cleanly against `main` on its own.
