### PR TITLE
feat: force password change for the seeded default admin

### DIFF
--- a/database/utils/table_creation.py
+++ b/database/utils/table_creation.py
@@ -51,8 +51,16 @@ def create_tables():
                             password_hash VARCHAR(128) NOT NULL,
                             salt          VARCHAR(64) NOT NULL,
                             role          VARCHAR(16) DEFAULT 'user',
+                            must_change_password BOOLEAN DEFAULT FALSE,
                             created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                        )
+                       """
+    # CREATE TABLE IF NOT EXISTS above does not alter an existing table, so
+    # installs that already have a `users` table from before this column
+    # existed need an explicit migration.
+    migrate_users_must_change_password_sql = """
+                       ALTER TABLE users
+                       ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN DEFAULT FALSE
                        """
     conn = create_connection()
     if conn is None:
@@ -67,6 +75,9 @@ def create_tables():
         _, err3 = execute_query(conn, create_users_sql)
         if err3:
             raise RuntimeError(f"Failed to create users table: {err3}")
+        _, err4 = execute_query(conn, migrate_users_must_change_password_sql)
+        if err4:
+            raise RuntimeError(f"Failed to migrate users table (must_change_password): {err4}")
         logger.info("Database tables verified/created: psop, execution_records, users")
     finally:
         conn.close()

--- a/database/utils/user_store.py
+++ b/database/utils/user_store.py
@@ -40,7 +40,7 @@ def _generate_salt() -> str:
     return _secrets.token_hex(16)
 
 
-def create_user(username: str, password: str, role: str = "user") -> bool:
+def create_user(username: str, password: str, role: str = "user", must_change_password: bool = False) -> bool:
     """Create a new user. Returns True on success."""
     conn = create_connection()
     if conn is None:
@@ -50,8 +50,8 @@ def create_user(username: str, password: str, role: str = "user") -> bool:
         password_hash = _hash_password(password, salt)
         _, err = execute_query(
             conn,
-            "INSERT INTO users (username, password_hash, salt, role) VALUES (%s, %s, %s, %s)",
-            (username, password_hash, salt, role),
+            "INSERT INTO users (username, password_hash, salt, role, must_change_password) VALUES (%s, %s, %s, %s, %s)",
+            (username, password_hash, salt, role, must_change_password),
         )
         if err:
             logger.warning(f"Failed to create user '{username}': {err}")
@@ -70,7 +70,7 @@ def authenticate_user(username: str, password: str) -> Optional[dict]:
     try:
         result, err = execute_query(
             conn,
-            "SELECT username, password_hash, salt, role FROM users WHERE username = %s",
+            "SELECT username, password_hash, salt, role, must_change_password FROM users WHERE username = %s",
             (username,),
         )
         if err or not result:
@@ -79,9 +79,10 @@ def authenticate_user(username: str, password: str) -> Optional[dict]:
         stored_hash = row[1]
         salt = row[2]
         role = row[3]
+        must_change_password = bool(row[4])
         input_hash = _hash_password(password, salt)
         if _secrets.compare_digest(input_hash, stored_hash):
-            return {"username": row[0], "role": role}
+            return {"username": row[0], "role": role, "must_change_password": must_change_password}
         return None
     finally:
         conn.close()
@@ -110,12 +111,15 @@ def list_users() -> list[dict]:
     try:
         result, err = execute_query(
             conn,
-            "SELECT username, role, created_at FROM users ORDER BY created_at",
+            "SELECT username, role, must_change_password, created_at FROM users ORDER BY created_at",
             None,
         )
         if err or not result:
             return []
-        return [{"username": r[0], "role": r[1], "created_at": str(r[2])} for r in result]
+        return [
+            {"username": r[0], "role": r[1], "must_change_password": bool(r[2]), "created_at": str(r[3])}
+            for r in result
+        ]
     finally:
         conn.close()
 
@@ -151,7 +155,10 @@ def has_any_user() -> bool:
 
 
 def update_password(username: str, new_password: str) -> bool:
-    """Update a user's password. Returns True on success."""
+    """Update a user's password and clear any pending forced-change flag.
+
+    Returns True on success.
+    """
     conn = create_connection()
     if conn is None:
         return False
@@ -160,7 +167,7 @@ def update_password(username: str, new_password: str) -> bool:
         password_hash = _hash_password(new_password, salt)
         _, err = execute_query(
             conn,
-            "UPDATE users SET password_hash = %s, salt = %s WHERE username = %s",
+            "UPDATE users SET password_hash = %s, salt = %s, must_change_password = FALSE WHERE username = %s",
             (password_hash, salt, username),
         )
         if err:
@@ -172,7 +179,11 @@ def update_password(username: str, new_password: str) -> bool:
         conn.close()
 
 def seed_admin_if_empty(default_password: str = "OpenAN@2026") -> bool:
-    """Create default admin user if no users exist."""
+    """Create default admin user if no users exist.
+
+    The seeded admin is flagged must_change_password so the well-known
+    default credential can't be used indefinitely (see #12).
+    """
     if has_any_user():
         return False
-    return create_user("admin", default_password, "admin")
+    return create_user("admin", default_password, "admin", must_change_password=True)

--- a/orchestrate/server/auth.py
+++ b/orchestrate/server/auth.py
@@ -184,6 +184,40 @@ def require_admin(request: Request) -> None:
         raise HTTPException(status_code=403, detail="Admin role required")
 
 
+# Usernames that must change their password before anything else is allowed.
+# Populated at login from the DB (see #12) rather than re-queried per
+# request, matching the session-role pattern -- avoids a DB round trip on
+# every authenticated request. Self-healing across restarts: the set is
+# empty on startup, but the next login for a still-pending user repopulates
+# it from the DB's own must_change_password column.
+_pending_password_change: set[str] = set()
+_pending_password_change_lock = threading.Lock()
+
+# Authenticated paths that must stay reachable for a user stuck in the
+# forced-change state, or they'd have no way to actually clear it.
+_PASSWORD_CHANGE_EXEMPT_PATHS = {
+    "/rest/v1/orchestrate/auth/change-password",
+    "/rest/v1/orchestrate/auth/logout",
+}
+
+
+def mark_must_change_password(username: str) -> None:
+    with _pending_password_change_lock:
+        _pending_password_change.add(username)
+
+
+def clear_must_change_password(username: str) -> None:
+    with _pending_password_change_lock:
+        _pending_password_change.discard(username)
+
+
+def username_must_change_password(username: str | None) -> bool:
+    if not username:
+        return False
+    with _pending_password_change_lock:
+        return username in _pending_password_change
+
+
 async def auth_middleware(request: Request, call_next):
     """Token-based auth for internal API; mTLS handles external API at TLS layer.
 
@@ -216,6 +250,13 @@ async def auth_middleware(request: Request, call_next):
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
             content=error(401, "Unauthorized: valid token required"),
+        )
+
+    username = _session_store.get_username(token)
+    if username_must_change_password(username) and path not in _PASSWORD_CHANGE_EXEMPT_PATHS:
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content=error(403, "Password change required", data={"must_change_password": True}),
         )
 
     return await call_next(request)

--- a/orchestrate/server/frontend_support_server.py
+++ b/orchestrate/server/frontend_support_server.py
@@ -66,6 +66,9 @@ from orchestrate.server.auth import (
     get_session_store,
     auth_middleware,
     require_admin,
+    mark_must_change_password,
+    clear_must_change_password,
+    username_must_change_password,
 )
 
 app = FastAPI(title="Workflow Orchestration API", version="1.0.0", docs_url=None, redoc_url=None, openapi_url=None)
@@ -208,9 +211,18 @@ async def login(request: LoginRequest, _: Any = Depends(LoginRateLimiter(config)
         user = authenticate_user(request.username, request.password)
         if user is not None:
             role = user.get("role", "user")
+            must_change = user.get("must_change_password", False)
+            if must_change:
+                mark_must_change_password(user["username"])
+            else:
+                clear_must_change_password(user["username"])
             token, ttl = get_session_store().create(user["username"], role)
             logger.info(f"Login successful (DB): {user['username']}")
-            return ok(data={"auth_required": True, "token": token, "expires_in": ttl, "username": user["username"], "role": role})
+            return ok(data={
+                "auth_required": True, "token": token, "expires_in": ttl,
+                "username": user["username"], "role": role,
+                "must_change_password": must_change,
+            })
         logger.warning(f"Login failed: username={request.username}")
         raise HTTPException(status_code=401, detail="Incorrect username or password")
     # File mode: config-based auth
@@ -255,7 +267,11 @@ async def auth_check(request: Request):
     token = auth_header[7:].strip() if auth_header.startswith("Bearer ") else None
     if token and get_session_store().validate(token):
         username = get_session_store().get_username(token)
-        return ok(data={"auth_required": True, "authenticated": True, "username": username, "registration_enabled": registration_enabled})
+        return ok(data={
+            "auth_required": True, "authenticated": True, "username": username,
+            "registration_enabled": registration_enabled,
+            "must_change_password": username_must_change_password(username),
+        })
     return ok(data={"auth_required": True, "authenticated": False, "registration_enabled": registration_enabled})
 
 @router.get("/auth/users")
@@ -327,6 +343,7 @@ async def change_password(request: ChangePasswordRequest, http_request: Request)
         if user is None:
             raise HTTPException(status_code=401, detail="Current password is incorrect")
         if update_password(username, request.new_password):
+            clear_must_change_password(username)
             logger.info(f"Password changed for user '{username}'")
             return ok(message="Password changed successfully")
         raise HTTPException(status_code=500, detail="Failed to change password")

--- a/orchestrate/start.py
+++ b/orchestrate/start.py
@@ -159,7 +159,7 @@ def main():
         import hashlib
         default_pw_hash = hashlib.sha256(b"OpenAN@2026").hexdigest()
         if seed_admin_if_empty(default_pw_hash):
-            logger.info("Default admin user created (password: OpenAN@2026)")
+            logger.info("Default admin user 'admin' created; a password change is required on first login")
         else:
             logger.info("Users already exist, skipping admin seed")
     if not is_enable_https:

--- a/tests/test_password_change_enforcement.py
+++ b/tests/test_password_change_enforcement.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import pytest
+from fastapi import Request
+from fastapi.responses import PlainTextResponse
+
+from orchestrate.server import auth as auth_module
+from orchestrate.server.auth import (
+    mark_must_change_password,
+    clear_must_change_password,
+    username_must_change_password,
+    auth_middleware,
+    get_session_store,
+)
+
+
+def _make_request(path, token=None, method="GET"):
+    headers = []
+    if token:
+        headers.append((b"authorization", f"Bearer {token}".encode()))
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": headers,
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+async def _call_next(request):
+    return PlainTextResponse("ok")
+
+
+class TestPendingPasswordChangeTracking:
+    """Regression coverage for #12: forced password change on first login."""
+
+    def test_username_must_change_password_false_by_default(self):
+        assert username_must_change_password("nobody-marked") is False
+
+    def test_mark_and_check(self):
+        clear_must_change_password("temp-user")
+        mark_must_change_password("temp-user")
+        try:
+            assert username_must_change_password("temp-user") is True
+        finally:
+            clear_must_change_password("temp-user")
+
+    def test_clear_removes_flag(self):
+        mark_must_change_password("temp-user-2")
+        clear_must_change_password("temp-user-2")
+        assert username_must_change_password("temp-user-2") is False
+
+    def test_none_username_is_never_flagged(self):
+        assert username_must_change_password(None) is False
+
+
+@pytest.mark.anyio
+class TestAuthMiddlewareEnforcement:
+    async def test_blocks_non_exempt_path_when_flagged(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        store = get_session_store()
+        token, _ = store.create("must-change-user")
+        mark_must_change_password("must-change-user")
+        try:
+            request = _make_request("/rest/v1/orchestrate/workflows", token=token)
+            response = await auth_middleware(request, _call_next)
+            assert response.status_code == 403
+        finally:
+            store.revoke(token)
+            clear_must_change_password("must-change-user")
+
+    async def test_allows_change_password_path_when_flagged(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        store = get_session_store()
+        token, _ = store.create("must-change-user-2")
+        mark_must_change_password("must-change-user-2")
+        try:
+            request = _make_request("/rest/v1/orchestrate/auth/change-password", token=token, method="POST")
+            response = await auth_middleware(request, _call_next)
+            assert response.status_code == 200
+        finally:
+            store.revoke(token)
+            clear_must_change_password("must-change-user-2")
+
+    async def test_allows_logout_path_when_flagged(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        store = get_session_store()
+        token, _ = store.create("must-change-user-3")
+        mark_must_change_password("must-change-user-3")
+        try:
+            request = _make_request("/rest/v1/orchestrate/auth/logout", token=token, method="POST")
+            response = await auth_middleware(request, _call_next)
+            assert response.status_code == 200
+        finally:
+            store.revoke(token)
+            clear_must_change_password("must-change-user-3")
+
+    async def test_allows_normal_path_once_cleared(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        store = get_session_store()
+        token, _ = store.create("cleared-user")
+        try:
+            request = _make_request("/rest/v1/orchestrate/workflows", token=token)
+            response = await auth_middleware(request, _call_next)
+            assert response.status_code == 200
+        finally:
+            store.revoke(token)

--- a/tests/test_table_creation.py
+++ b/tests/test_table_creation.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from database.utils import table_creation
+
+
+class TestCreateTables:
+    def test_runs_must_change_password_migration(self):
+        with patch.object(table_creation, "create_connection", return_value=MagicMock()), \
+             patch.object(table_creation, "execute_query", return_value=(None, None)) as mock_exec:
+            table_creation.create_tables()
+            queries = [call.args[1] for call in mock_exec.call_args_list]
+            assert any("ADD COLUMN IF NOT EXISTS must_change_password" in q for q in queries)
+
+    def test_raises_when_migration_fails(self):
+        def _fake_execute(conn, query, *args, **kwargs):
+            if "ALTER TABLE" in query and "must_change_password" in query:
+                return None, RuntimeError("boom")
+            return None, None
+
+        with patch.object(table_creation, "create_connection", return_value=MagicMock()), \
+             patch.object(table_creation, "execute_query", side_effect=_fake_execute):
+            with pytest.raises(RuntimeError, match="Failed to migrate users table"):
+                table_creation.create_tables()
+
+    def test_raises_when_no_connection(self):
+        with patch.object(table_creation, "create_connection", return_value=None):
+            with pytest.raises(RuntimeError, match="Unable to create database connection"):
+                table_creation.create_tables()

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from unittest.mock import MagicMock, patch
+
+from database.utils import user_store
+
+
+def _mock_conn():
+    return MagicMock()
+
+
+class TestCreateUser:
+    def test_defaults_role_and_must_change_password(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, None)) as mock_exec:
+            assert user_store.create_user("alice", "pw") is True
+            params = mock_exec.call_args[0][2]
+            assert params[3] == "user"
+            assert params[4] is False
+
+    def test_passes_through_role_and_must_change_password(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, None)) as mock_exec:
+            assert user_store.create_user("admin", "pw", role="admin", must_change_password=True) is True
+            params = mock_exec.call_args[0][2]
+            assert params[3] == "admin"
+            assert params[4] is True
+
+    def test_returns_false_on_db_error(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, RuntimeError("boom"))):
+            assert user_store.create_user("alice", "pw") is False
+
+    def test_returns_false_when_no_connection(self):
+        with patch.object(user_store, "create_connection", return_value=None):
+            assert user_store.create_user("alice", "pw") is False
+
+
+class TestAuthenticateUser:
+    def _row_for(self, password, salt="salt123", role="user", must_change_password=False):
+        password_hash = user_store._hash_password(password, salt)
+        return ("alice", password_hash, salt, role, must_change_password)
+
+    def test_returns_user_dict_on_correct_password(self):
+        row = self._row_for("correct-horse")
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)):
+            result = user_store.authenticate_user("alice", "correct-horse")
+            assert result == {"username": "alice", "role": "user", "must_change_password": False}
+
+    def test_surfaces_must_change_password_true(self):
+        row = self._row_for("OpenAN@2026", role="admin", must_change_password=True)
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)):
+            result = user_store.authenticate_user("alice", "OpenAN@2026")
+            assert result["must_change_password"] is True
+
+    def test_returns_none_on_wrong_password(self):
+        row = self._row_for("correct-horse")
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)):
+            assert user_store.authenticate_user("alice", "wrong") is None
+
+    def test_returns_none_when_user_not_found(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([], None)):
+            assert user_store.authenticate_user("nobody", "pw") is None
+
+
+class TestUpdatePassword:
+    def test_clears_must_change_password_flag(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, None)) as mock_exec:
+            assert user_store.update_password("alice", "new-pw") is True
+            query = mock_exec.call_args[0][1]
+            assert "must_change_password = FALSE" in query
+
+    def test_returns_false_on_db_error(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, RuntimeError("boom"))):
+            assert user_store.update_password("alice", "new-pw") is False
+
+
+class TestSeedAdminIfEmpty:
+    def test_creates_admin_flagged_must_change_password(self):
+        with patch.object(user_store, "has_any_user", return_value=False), \
+             patch.object(user_store, "create_user", return_value=True) as mock_create:
+            assert user_store.seed_admin_if_empty("hashed-default") is True
+            mock_create.assert_called_once_with("admin", "hashed-default", "admin", must_change_password=True)
+
+    def test_no_op_when_users_already_exist(self):
+        with patch.object(user_store, "has_any_user", return_value=True), \
+             patch.object(user_store, "create_user") as mock_create:
+            assert user_store.seed_admin_if_empty("hashed-default") is False
+            mock_create.assert_not_called()
+
+
+class TestListUsers:
+    def test_includes_must_change_password(self):
+        rows = [("alice", "admin", True, "2026-01-01 00:00:00")]
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(rows, None)):
+            result = user_store.list_users()
+            assert result == [{
+                "username": "alice", "role": "admin",
+                "must_change_password": True, "created_at": "2026-01-01 00:00:00",
+            }]

--- a/workflow-designer/src/App.jsx
+++ b/workflow-designer/src/App.jsx
@@ -18,6 +18,7 @@ import {useTranslation} from "react-i18next";
 import {useEffect, useState} from "react";
 import Header from "@/components/common/header/index.jsx";
 import Login from "@/components/common/login/index.jsx";
+import PasswordChangeModal from "@/components/common/password_change/index.jsx";
 import {authCheck, setAuthToken} from "@/service/api.js";
 import AgentRegistry from "./components/registry_center/index.jsx";
 import OrchestrationCenter from "@/components/orchestration_center/index.jsx";
@@ -32,6 +33,7 @@ const MainContainer = () => {
    const [authRequired, setAuthRequired] = useState(false);
    const [registrationEnabled, setRegistrationEnabled] = useState(false);
    const [currentUser, setCurrentUser] = useState(null);
+   const [mustChangePassword, setMustChangePassword] = useState(false);
 
    const [isDark, setIsDark] = useState(() => {
         const savedTheme = localStorage.getItem('theme');
@@ -45,6 +47,7 @@ const MainContainer = () => {
                    setAuthRequired(data.auth_required !== false);
                    setRegistrationEnabled(data.registration_enabled || false);
                    setCurrentUser(data.username || null);
+                   setMustChangePassword(!!data.must_change_password);
                    setAuthState('authenticated');
                } else {
                    setAuthRequired(true);
@@ -65,6 +68,7 @@ const MainContainer = () => {
        setAuthToken(null);
        setAuthState('unauthenticated');
        setCurrentUser(null);
+       setMustChangePassword(false);
    };
 
    const [activeTab, setActiveTab] = useState(() => {
@@ -110,11 +114,19 @@ const MainContainer = () => {
            <Login
                isDark={isDark}
                onLoginSuccess={() => setAuthState('authenticated')}
-               onLoginWithUser={(user) => { setCurrentUser(user); setAuthState('authenticated'); }}
+               onLoginWithUser={(user, mustChange) => { setCurrentUser(user); setMustChangePassword(!!mustChange); setAuthState('authenticated'); }}
                registrationEnabled={registrationEnabled}
            />
         ) : (
         <div className="h-screen flex flex-col bg-zinc-50 dark:bg-[#09090B] overflow-hidden font-sans text-lg transition-colors duration-500">
+           {mustChangePassword && (
+               <PasswordChangeModal
+                   isOpen={true}
+                   forced={true}
+                   onClose={() => {}}
+                   t={t}
+               />
+           )}
            <Header
                currentTab={activeTab}
                onTabChange={setActiveTab}

--- a/workflow-designer/src/components/common/login/index.jsx
+++ b/workflow-designer/src/components/common/login/index.jsx
@@ -31,7 +31,7 @@ const {t, i18n} = useTranslation();
         try {
            const data = await login(username, password);
            if (data && data.token) {
-                onLoginWithUser ? onLoginWithUser(data.username) : onLoginSuccess();
+                onLoginWithUser ? onLoginWithUser(data.username, data.must_change_password) : onLoginSuccess();
            } else if (data && data.auth_required === false) {
                onLoginSuccess();
            }
@@ -64,8 +64,8 @@ const {t, i18n} = useTranslation();
             await register(username, password);
             const data = await login(username, password);
            if (data && data.token) {
-                onLoginWithUser ? onLoginWithUser(data.username) : onLoginSuccess();
-            } 
+                onLoginWithUser ? onLoginWithUser(data.username, data.must_change_password) : onLoginSuccess();
+            }
        } catch (err) {
             const msg = err?.response?.data?.message || err?.message || "";
             setError(msg || t('login.error'));

--- a/workflow-designer/src/components/common/password_change/index.jsx
+++ b/workflow-designer/src/components/common/password_change/index.jsx
@@ -19,7 +19,7 @@ import {useTranslation} from "react-i18next";
 import {Lock, X, Save, AlertCircle, Loader2, KeyRound} from "lucide-react";
 import {changePassword} from "@/service/api.js";
 
-const PasswordChangeModal = ({isOpen, onClose, t}) => {
+const PasswordChangeModal = ({isOpen, onClose, t, forced = false}) => {
     const [oldPassword, setOldPassword] = useState("");
     const [newPassword, setNewPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
@@ -67,11 +67,19 @@ const PasswordChangeModal = ({isOpen, onClose, t}) => {
                         </div>
                         <h2 className={"text-lg font-black dark:text-white"}>{t('login.change_password')}</h2>
                     </div>
-                    <button className={"p-2 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-full transition-colors"} onClick={onClose}>
-                        <X size={20} className={"text-zinc-400"}/>
-                    </button>
+                    {!forced && (
+                        <button className={"p-2 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-full transition-colors"} onClick={onClose}>
+                            <X size={20} className={"text-zinc-400"}/>
+                        </button>
+                    )}
                 </div>
                 <form onSubmit={handleSubmit} className={"p-8 space-y-5"}>
+                    {forced && (
+                        <div className={"flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40 rounded-xl p-3"}>
+                            <AlertCircle size={16} className={"shrink-0"}/>
+                            <span>{t('login.must_change_password')}</span>
+                        </div>
+                    )}
                     <div className={"space-y-2"}>
                         <label className={"text-[10px] font-black text-zinc-400 ml-1"}>{t('login.current_password')}</label>
                         <div className={"relative"}>
@@ -116,10 +124,12 @@ const PasswordChangeModal = ({isOpen, onClose, t}) => {
                         </div>
                     )}
                     <div className={"flex gap-3 pt-2"}>
-                        <button type={"button"} onClick={onClose}
-                                className={"flex-1 py-3 rounded-xl font-black text-xs text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-all"}>
-                            {t('common.cancel')}
-                        </button>
+                        {!forced && (
+                            <button type={"button"} onClick={onClose}
+                                    className={"flex-1 py-3 rounded-xl font-black text-xs text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-all"}>
+                                {t('common.cancel')}
+                            </button>
+                        )}
                         <button type={"submit"} disabled={loading}
                                 className={"flex-1 py-3 rounded-xl text-xs bg-blue-600 text-white shadow-lg shadow-blue-500/20 hover:bg-blue-700 active:scale-95 transition-all flex items-center justify-center gap-2"}>
                             {loading ? (<><Loader2 size={16} className="animate-spin"/> {t('login.loading')}</>) : (<><Save size={16}/> {t('login.change_password')}</>)}

--- a/workflow-designer/src/locales/en.json
+++ b/workflow-designer/src/locales/en.json
@@ -26,7 +26,8 @@
     "password_complexity": "Password must contain uppercase, lowercase, and a number",
     "change_password": "Change Password",
     "current_password": "Current Password",
-    "new_password": "New Password"
+    "new_password": "New Password",
+    "must_change_password": "This account is using a default password. Choose a new password to continue."
   },
   "execution": {
     "title": "Execution Center",

--- a/workflow-designer/src/locales/zh.json
+++ b/workflow-designer/src/locales/zh.json
@@ -26,7 +26,8 @@
     "password_complexity": "密码必须包含大写字母、小写字母和数字",
     "change_password": "修改密码",
     "current_password": "当前密码",
-    "new_password": "新密码"
+    "new_password": "新密码",
+    "must_change_password": "该账户正在使用默认密码，请设置新密码后继续。"
   },
   "execution": {
     "title": "工作流执行",


### PR DESCRIPTION
## Description

`orchestrate/start.py` logged the seeded admin's plaintext default password (`"Default admin user created (password: OpenAN@2026)"`) on every fresh `persistence_mode=postgresql` deployment. Log aggregation/storage often has broader access than the docs where this password is already documented, so this was an unnecessary additional disclosure surface. More importantly, there was no mechanism to force a credential change on first login — an operator who missed the README callout could run indefinitely on the well-known default, which via hw-irc-sni/orchestration-center#8 is one unthrottled `POST /auth/login` away from full compromise.

## What changed

- Dropped the plaintext password from the startup log line.
- Added a `must_change_password` column to the `users` table: the DDL for fresh installs, plus an `ALTER TABLE users ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN DEFAULT FALSE` migration for existing installs, since `CREATE TABLE IF NOT EXISTS` doesn't alter a table that already exists.
- `seed_admin_if_empty()` now flags the seeded admin; `update_password()` clears the flag on any password change (forced or voluntary).
- `auth_middleware` blocks every internal API call for a flagged session except `/auth/change-password` and `/auth/logout` — so there's no way to use the app on a default credential without changing it first. The flag is tracked in-memory (`mark_must_change_password` / `clear_must_change_password` / `username_must_change_password` in `orchestrate/server/auth.py`) rather than queried from the DB per request — this check runs on every authenticated call, and a DB round trip there would add to the same hot-path load flagged in hw-irc-sni/orchestration-center#40. It's populated fresh from the DB at each login, so it self-heals across process restarts without needing persistent in-memory state.
- `POST /auth/login` and `GET /auth/check` now surface `must_change_password` in their response, so the frontend can show the change-password screen proactively instead of the user only finding out via a blocked request.
- Frontend: the existing `PasswordChangeModal` (previously only reachable voluntarily from Settings) gained a `forced` prop that hides its dismiss/cancel controls. `App.jsx` renders it, non-dismissible, whenever the backend reports `must_change_password: true` — on login and on every page load via `/auth/check`.

## Deliberately out of scope

File mode is unaffected: it has no per-user DB row to flag and no seeded admin (the file-mode credential is a single global `access_password`) — only the `persistence_mode=postgresql` seed path applies.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

Validated locally:
- `pytest tests/ --ignore=tests/test_external_apis.py` — 354 passed, 7 pre-existing skips, 0 failures. 24 new backend tests: `tests/test_user_store.py` (13, covering `create_user`/`authenticate_user`/`update_password`/`seed_admin_if_empty`/`list_users`), `tests/test_table_creation.py` (3, covering the migration), `tests/test_password_change_enforcement.py` (8, covering the in-memory flag helpers and `auth_middleware` enforcement — exempt paths stay reachable, everything else 403s until cleared).
- `npm run lint` — 0 errors, 31 warnings (unchanged from the `main` baseline, confirmed by diffing against a clean checkout).
- `npm run build` — succeeds.
- `npm run test` — 27/27 passed (pre-existing suite, unaffected).

This is `database/utils/user_store.py`'s and `database/utils/table_creation.py`'s first test coverage — this whole area was previously untested, which is what hw-irc-sni/orchestration-center#16 tracks project-wide; this PR only covers what it touches.

One of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37. Fourth in the recommended sequence (#7 → #8 → #13 → #12 → #14 → #9 → #16) — deliberately landing before #9, which is expected to touch this same `users` table and credential format, so that PR's rewrite doesn't collide with this migration. Independent of #7 (project-openan/orchestration-center#56), #8 (project-openan/orchestration-center#57), and #13 (project-openan/orchestration-center#58); applies cleanly against `main` on its own.
