### PR TITLE
docs: document the session store's single-process constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ The internal API (`/rest/v1/orchestrate/*`) is protected by token-based authenti
 
 The frontend hashes the password with SHA-256 (`crypto.subtle`) before sending. Tokens are in-memory with TTL, passed via `Authorization: Bearer` header or `access_token` query parameter (for SSE/EventSource).
 
+> **Session storage is single-process only.** Tokens live in an in-memory dict inside the running Python process. Running with multiple `uvicorn` workers, or multiple replicas behind a load balancer, will intermittently reject valid tokens -- a token minted by one worker isn't visible to another. Every process restart also logs out all active sessions (harmless in itself given the token TTL, but worth expecting). Both bundled launch paths (`orchestrate/start.py`) run single-process today, so this doesn't bite out of the box -- but if multi-worker or multi-replica deployment is ever needed, session storage must move to a shared backend (e.g. the same PostgreSQL database, or Redis) first.
+
 Generate the password hash (file mode):
 ```bash
 python generate_access_password.py

--- a/README_zh.md
+++ b/README_zh.md
@@ -295,6 +295,8 @@ flowchart TB
 
 前端使用 `crypto.subtle` 对密码做 SHA-256 哈希后发送。令牌存储在内存中，通过 `Authorization: Bearer` 请求头或 `access_token` 查询参数（用于 SSE/EventSource）传递。
 
+> **会话存储仅限单进程。** 令牌保存在运行中 Python 进程的内存字典中。若以多个 `uvicorn` worker 运行，或在负载均衡后部署多个副本，会间歇性地拒绝本应有效的令牌——因为某个 worker 签发的令牌对其他 worker 不可见。每次进程重启也会导致所有活动会话登出（鉴于令牌本身有 TTL，这本身无害，但仍需提前预期）。当前内置的两条启动路径（`orchestrate/start.py`）都是单进程运行，因此默认情况下不会触发此问题——但如果之后需要多 worker 或多副本部署，必须先将会话存储迁移到共享后端（例如现有的 PostgreSQL 数据库，或 Redis）。
+
 生成密码哈希（file 模式）：
 ```bash
 python generate_access_password.py

--- a/orchestrate/server/auth.py
+++ b/orchestrate/server/auth.py
@@ -80,7 +80,15 @@ def _get_ttl() -> int:
 
 
 class _SessionStore:
-    """Thread-safe in-memory token store with TTL."""
+    """Thread-safe in-memory token store with TTL.
+
+    Single-process only (see #14): a token minted by one worker/replica
+    isn't visible to another, and every restart drops all sessions. Fine
+    for the single-process launch paths this project ships today; revisit
+    with a shared backend (DB/Redis) before ever running multiple workers
+    or replicas. See the "Session storage is single-process only" note in
+    README.md for the operator-facing version of this.
+    """
 
     def __init__(self):
         # token -> (username, expiry epoch)


### PR DESCRIPTION
## Description

`_SessionStore` in `orchestrate/server/auth.py` is a plain in-memory `dict` guarded by a `threading.Lock`, held as a module-level singleton. That's fine for a single-process deployment, but:

- If the app is ever run with multiple `uvicorn` workers or multiple replicas behind a load balancer, a token minted by one worker won't validate on a request routed to a different worker — intermittent, hard-to-diagnose 401s.
- Every process restart (deploy, crash, `systemctl restart`) silently logs out every active user, with no persistence.

Neither was documented anywhere near the `enable_https`/`persistence_mode` config docs, or in code.

## Why documentation, not a shared-backend rewrite

Checked whether this is live: nothing in this repo passes `--workers` to `uvicorn` or runs multiple replicas — both bundled launch paths (`orchestrate/start.py`) are single-process today. This is a trap waiting for a future deployment change, not a bug anyone is hitting. Introducing a shared session backend (Redis, or a `sessions` table) to solve a problem no current deployment has isn't justified — it adds a dependency and an operational surface for nothing. If multi-replica deployment lands on the roadmap, this should be revisited properly at that point (and, per the discussion on hw-irc-sni/orchestration-center#37, potentially combined with hw-irc-sni/orchestration-center#9 if that PR ends up issuing an httpOnly session cookie and touching this same code).

## What changed

- `README.md` / `README_zh.md`: added a note next to the session-token paragraph in the Security section, explaining the single-process constraint and when it would start to matter.
- `orchestrate/server/auth.py`: expanded `_SessionStore`'s docstring with the same constraint, pointing back to the README note.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [ ] I have added tests that prove my fix is effective or my feature works (if applicable) -- documentation-only change
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header -- no new source files

## Additional Context

Validated locally: `pytest tests/ --ignore=tests/test_external_apis.py` — 330 passed, 7 pre-existing skips, 0 failures (unaffected, as expected for a docs-only change).

One of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37. Fifth in the recommended sequence (#7 → #8 → #13 → #12 → #14 → #9 → #16), though as a documentation-only change it doesn't conflict with anything and can land at any point.
