### PR TITLE
feat: hash passwords server-side instead of trusting a client-side digest (9a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,10 +350,10 @@ The Orchestration Center provides multi-layer access control:
 The internal API (`/rest/v1/orchestrate/*`) is protected by token-based authentication. Two modes are supported depending on `persistence_mode`:
 
 **Database mode (`persistence_mode=postgresql`)**:
-- Users are stored in the PostgreSQL `users` table with SHA-256 + per-user salt hashing.
+- The plaintext password is sent to the backend (over TLS -- see below) and hashed there with SHA-256 + a per-user salt; the server never persists or compares a client-computed hash.
 - A default `admin` user (password: `OpenAN@2026`) is auto-created on first startup.
 - New users can self-register via the registration link on the login page.
-- Passwords must be at least 8 characters with uppercase, lowercase, and a number.
+- Passwords must be at least 8 characters and include at least two of: a digit, an uppercase letter, a lowercase letter, a special character. Enforced server-side (`common/util/password_util.validate_password_complexity`), not just in the UI.
 
 **File mode (`persistence_mode=file`)**:
 - A single password is configured via `access_password` in `server.conf`.
@@ -366,7 +366,7 @@ The internal API (`/rest/v1/orchestrate/*`) is protected by token-based authenti
 | `access_token_ttl` | Session token lifetime in seconds. | `43200` (12h) |
 | `persistence_mode` | `postgresql` enables database-backed user management; `file` uses config-based auth. | `file` |
 
-The frontend hashes the password with SHA-256 (`crypto.subtle`) before sending. Tokens are in-memory with TTL, passed via `Authorization: Bearer` header or `access_token` query parameter (for SSE/EventSource).
+The frontend sends the password as-is; the backend is what hashes it (server-side, salted, for DB-mode accounts; against the configured SHA-256 in file mode). **This relies on `enable_https=true` for confidentiality in transit** -- see the TLS/HTTPS section below; don't run with the shipped `enable_https=false` default outside local development. Tokens are in-memory with TTL, passed via `Authorization: Bearer` header or `access_token` query parameter (for SSE/EventSource).
 
 > **Session storage is single-process only.** Tokens live in an in-memory dict inside the running Python process. Running with multiple `uvicorn` workers, or multiple replicas behind a load balancer, will intermittently reject valid tokens -- a token minted by one worker isn't visible to another. Every process restart also logs out all active sessions (harmless in itself given the token TTL, but worth expecting). Both bundled launch paths (`orchestrate/start.py`) run single-process today, so this doesn't bite out of the box -- but if multi-worker or multi-replica deployment is ever needed, session storage must move to a shared backend (e.g. the same PostgreSQL database, or Redis) first.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -277,10 +277,10 @@ flowchart TB
 内部 API（`/rest/v1/orchestrate/*`）受令牌认证保护。根据 `persistence_mode` 支持两种模式：
 
 **数据库模式（`persistence_mode=postgresql`）**：
-- 用户存储在 PostgreSQL `users` 表中，密码使用 SHA-256 + 每用户独立 salt 哈希。
+- 明文密码发送到后端（需经由 TLS，见下文），由后端使用 SHA-256 + 每用户独立 salt 哈希；服务器不再持久化或比对由客户端计算出的哈希值。
 - 首次启动自动创建默认 `admin` 用户（密码：`OpenAN@2026`）。
 - 新用户可通过登录页的注册链接自行注册。
-- 密码要求至少 8 位，包含大写字母、小写字母和数字。
+- 密码要求至少 8 位，且至少包含以下两类字符：数字、大写字母、小写字母、特殊字符。该策略在服务端强制校验（`common/util/password_util.validate_password_complexity`），而不仅仅是前端界面提示。
 
 **文件模式（`persistence_mode=file`）**：
 - 通过 `server.conf` 的 `access_password` 配置单一密码。
@@ -293,7 +293,7 @@ flowchart TB
 | `access_token_ttl` | 会话令牌有效期（秒）。 | `43200`（12小时） |
 | `persistence_mode` | `postgresql` 启用数据库用户管理；`file` 使用配置密码认证。 | `file` |
 
-前端使用 `crypto.subtle` 对密码做 SHA-256 哈希后发送。令牌存储在内存中，通过 `Authorization: Bearer` 请求头或 `access_token` 查询参数（用于 SSE/EventSource）传递。
+前端按原样发送密码；由后端负责哈希（数据库模式下按用户加盐哈希；文件模式下与配置的 SHA-256 值比对）。**这依赖 `enable_https=true` 来保证传输过程的机密性**——见下方 TLS/HTTPS 一节；除本地开发外，不要使用默认的 `enable_https=false`。令牌存储在内存中，通过 `Authorization: Bearer` 请求头或 `access_token` 查询参数（用于 SSE/EventSource）传递。
 
 > **会话存储仅限单进程。** 令牌保存在运行中 Python 进程的内存字典中。若以多个 `uvicorn` worker 运行，或在负载均衡后部署多个副本，会间歇性地拒绝本应有效的令牌——因为某个 worker 签发的令牌对其他 worker 不可见。每次进程重启也会导致所有活动会话登出（鉴于令牌本身有 TTL，这本身无害，但仍需提前预期）。当前内置的两条启动路径（`orchestrate/start.py`）都是单进程运行，因此默认情况下不会触发此问题——但如果之后需要多 worker 或多副本部署，必须先将会话存储迁移到共享后端（例如现有的 PostgreSQL 数据库，或 Redis）。
 

--- a/database/utils/table_creation.py
+++ b/database/utils/table_creation.py
@@ -52,15 +52,22 @@ def create_tables():
                             salt          VARCHAR(64) NOT NULL,
                             role          VARCHAR(16) DEFAULT 'user',
                             must_change_password BOOLEAN DEFAULT FALSE,
+                            password_scheme VARCHAR(16) DEFAULT 'legacy',
                             created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                        )
                        """
     # CREATE TABLE IF NOT EXISTS above does not alter an existing table, so
-    # installs that already have a `users` table from before this column
-    # existed need an explicit migration.
+    # installs that already have a `users` table from before these columns
+    # existed need an explicit migration. Existing rows correctly default
+    # password_scheme to 'legacy' -- see user_store.authenticate_user() for
+    # what that means.
     migrate_users_must_change_password_sql = """
                        ALTER TABLE users
                        ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN DEFAULT FALSE
+                       """
+    migrate_users_password_scheme_sql = """
+                       ALTER TABLE users
+                       ADD COLUMN IF NOT EXISTS password_scheme VARCHAR(16) DEFAULT 'legacy'
                        """
     conn = create_connection()
     if conn is None:
@@ -78,6 +85,9 @@ def create_tables():
         _, err4 = execute_query(conn, migrate_users_must_change_password_sql)
         if err4:
             raise RuntimeError(f"Failed to migrate users table (must_change_password): {err4}")
+        _, err5 = execute_query(conn, migrate_users_password_scheme_sql)
+        if err5:
+            raise RuntimeError(f"Failed to migrate users table (password_scheme): {err5}")
         logger.info("Database tables verified/created: psop, execution_records, users")
     finally:
         conn.close()

--- a/database/utils/user_store.py
+++ b/database/utils/user_store.py
@@ -19,6 +19,13 @@
 
 Stores usernames and password hashes in the ``users`` table.
 Passwords are hashed with SHA-256 + per-user salt.
+
+``password`` parameters below take the real plaintext password (sent by
+the frontend over the wire, ideally under TLS). Rows created before #9
+(the ``password_scheme='legacy'`` ones) instead stored a hash of the
+*client's own* SHA-256 pre-hash of the password -- see
+``authenticate_user()`` for how those keep working without a forced
+reset.
 """
 
 import hashlib
@@ -29,6 +36,13 @@ from loguru import logger
 
 from database.utils.db_connection import create_connection
 from database.utils.query_execution import execute_query
+
+# Current on-disk password scheme: password_hash = _hash_password(plaintext, salt).
+# 'legacy' rows instead hold _hash_password(sha256(plaintext), salt) -- the
+# client used to pre-hash the password with SHA-256 before it ever reached
+# the backend, so the "password" that scheme's _hash_password() was ever
+# given is that digest, not the real plaintext.
+_CURRENT_PASSWORD_SCHEME = "v2"
 
 
 def _hash_password(password: str, salt: str) -> str:
@@ -41,7 +55,7 @@ def _generate_salt() -> str:
 
 
 def create_user(username: str, password: str, role: str = "user", must_change_password: bool = False) -> bool:
-    """Create a new user. Returns True on success."""
+    """Create a new user with the current password scheme. Returns True on success."""
     conn = create_connection()
     if conn is None:
         return False
@@ -50,8 +64,9 @@ def create_user(username: str, password: str, role: str = "user", must_change_pa
         password_hash = _hash_password(password, salt)
         _, err = execute_query(
             conn,
-            "INSERT INTO users (username, password_hash, salt, role, must_change_password) VALUES (%s, %s, %s, %s, %s)",
-            (username, password_hash, salt, role, must_change_password),
+            "INSERT INTO users (username, password_hash, salt, role, must_change_password, password_scheme) "
+            "VALUES (%s, %s, %s, %s, %s, %s)",
+            (username, password_hash, salt, role, must_change_password, _CURRENT_PASSWORD_SCHEME),
         )
         if err:
             logger.warning(f"Failed to create user '{username}': {err}")
@@ -62,15 +77,48 @@ def create_user(username: str, password: str, role: str = "user", must_change_pa
         conn.close()
 
 
+def _upgrade_password_scheme(username: str, password: str, salt: str) -> None:
+    """Re-hash a successfully-authenticated legacy row under the current scheme.
+
+    Only called after the legacy verification in authenticate_user() has
+    already confirmed ``password`` is correct, so this is a same-password
+    re-hash, not a credential change -- must_change_password is untouched.
+    """
+    conn = create_connection()
+    if conn is None:
+        return
+    try:
+        password_hash = _hash_password(password, salt)
+        _, err = execute_query(
+            conn,
+            "UPDATE users SET password_hash = %s, password_scheme = %s WHERE username = %s",
+            (password_hash, _CURRENT_PASSWORD_SCHEME, username),
+        )
+        if err:
+            logger.warning(f"Failed to upgrade password scheme for '{username}': {err}")
+        else:
+            logger.info(f"Upgraded '{username}' from legacy to '{_CURRENT_PASSWORD_SCHEME}' password scheme")
+    finally:
+        conn.close()
+
+
 def authenticate_user(username: str, password: str) -> Optional[dict]:
-    """Verify username/password. Returns user dict or None."""
+    """Verify username/plaintext password. Returns user dict or None.
+
+    Rows stored under the legacy scheme are verified by reconstructing the
+    client-side SHA-256 pre-hash the old frontend used to send, so existing
+    accounts keep working with the password their owner already knows --
+    no forced reset. A successful legacy login is opportunistically
+    upgraded to the current scheme.
+    """
     conn = create_connection()
     if conn is None:
         return None
     try:
         result, err = execute_query(
             conn,
-            "SELECT username, password_hash, salt, role, must_change_password FROM users WHERE username = %s",
+            "SELECT username, password_hash, salt, role, must_change_password, password_scheme "
+            "FROM users WHERE username = %s",
             (username,),
         )
         if err or not result:
@@ -80,10 +128,21 @@ def authenticate_user(username: str, password: str) -> Optional[dict]:
         salt = row[2]
         role = row[3]
         must_change_password = bool(row[4])
-        input_hash = _hash_password(password, salt)
-        if _secrets.compare_digest(input_hash, stored_hash):
-            return {"username": row[0], "role": role, "must_change_password": must_change_password}
-        return None
+        scheme = row[5] or "legacy"
+
+        if scheme == "legacy":
+            legacy_input = hashlib.sha256(password.encode()).hexdigest()
+            computed_hash = _hash_password(legacy_input, salt)
+        else:
+            computed_hash = _hash_password(password, salt)
+
+        if not _secrets.compare_digest(computed_hash, stored_hash):
+            return None
+
+        if scheme == "legacy":
+            _upgrade_password_scheme(username, password, salt)
+
+        return {"username": row[0], "role": role, "must_change_password": must_change_password}
     finally:
         conn.close()
 
@@ -155,9 +214,8 @@ def has_any_user() -> bool:
 
 
 def update_password(username: str, new_password: str) -> bool:
-    """Update a user's password and clear any pending forced-change flag.
-
-    Returns True on success.
+    """Update a user's password (plaintext) under the current scheme and
+    clear any pending forced-change flag. Returns True on success.
     """
     conn = create_connection()
     if conn is None:
@@ -167,8 +225,9 @@ def update_password(username: str, new_password: str) -> bool:
         password_hash = _hash_password(new_password, salt)
         _, err = execute_query(
             conn,
-            "UPDATE users SET password_hash = %s, salt = %s, must_change_password = FALSE WHERE username = %s",
-            (password_hash, salt, username),
+            "UPDATE users SET password_hash = %s, salt = %s, must_change_password = FALSE, "
+            "password_scheme = %s WHERE username = %s",
+            (password_hash, salt, _CURRENT_PASSWORD_SCHEME, username),
         )
         if err:
             logger.warning(f"Failed to update password for '{username}': {err}")

--- a/orchestrate/server/frontend_support_server.py
+++ b/orchestrate/server/frontend_support_server.py
@@ -16,6 +16,7 @@
 #    under the License.
 
 import os
+import hashlib
 import secrets
 import tempfile
 import threading
@@ -194,11 +195,11 @@ router = APIRouter(prefix="/rest/v1/orchestrate")
 
 class LoginRequest(BaseModel):
     username: str = Field(..., min_length=1, max_length=64, description="Username")
-    password: str = Field(..., min_length=1, max_length=256, description="Password (SHA-256 hashed by frontend)")
+    password: str = Field(..., min_length=1, max_length=256, description="Password (plaintext, sent over TLS)")
 
 class RegisterRequest(BaseModel):
     username: str = Field(..., min_length=3, max_length=64, description="Username")
-    password: str = Field(..., min_length=6, max_length=256, description="Password (SHA-256 hashed by frontend)")
+    password: str = Field(..., min_length=8, max_length=256, description="Password (plaintext, sent over TLS)")
 
 @router.post("/auth/login")
 async def login(request: LoginRequest, _: Any = Depends(LoginRateLimiter(config))):
@@ -225,9 +226,12 @@ async def login(request: LoginRequest, _: Any = Depends(LoginRateLimiter(config)
             })
         logger.warning(f"Login failed: username={request.username}")
         raise HTTPException(status_code=401, detail="Incorrect username or password")
-    # File mode: config-based auth
+    # File mode: config-based auth. access_password stores sha256(plaintext)
+    # (see generate_access_password.py); hash the incoming plaintext the
+    # same way before comparing.
     stored = conf.get("access_password", "")
-    if request.username == "admin" and stored and secrets.compare_digest(request.password, stored):
+    computed = hashlib.sha256(request.password.encode()).hexdigest()
+    if request.username == "admin" and stored and secrets.compare_digest(computed, stored):
         token, ttl = get_session_store().create("admin", "admin")
         logger.info("Login successful (config): admin")
         return ok(data={"auth_required": True, "token": token, "expires_in": ttl, "username": "admin", "role": "admin"})
@@ -241,6 +245,10 @@ async def register(request: RegisterRequest):
         raise HTTPException(status_code=400, detail="Registration requires PostgreSQL persistence mode")
     if not re.fullmatch(r"^[a-zA-Z][a-zA-Z0-9_-]{2,63}$", request.username):
         raise HTTPException(status_code=400, detail="Username must start with a letter and contain only letters, digits, underscores or hyphens (3-64 chars)")
+    from common.util.password_util import validate_password_complexity
+    is_valid, reason = validate_password_complexity(request.password)
+    if not is_valid:
+        raise HTTPException(status_code=400, detail=f"Password does not meet complexity requirements: {reason}")
     from database.utils.user_store import create_user, user_exists
     if user_exists(request.username):
         raise HTTPException(status_code=409, detail="Username already exists")
@@ -291,8 +299,8 @@ async def delete_user_endpoint(username: str, _: Any = Depends(require_admin)):
 
 
 class ChangePasswordRequest(BaseModel):
-    old_password: str = Field(..., min_length=1, max_length=256, description="Current password (SHA-256 hashed)")
-    new_password: str = Field(..., min_length=6, max_length=256, description="New password (SHA-256 hashed)")
+    old_password: str = Field(..., min_length=1, max_length=256, description="Current password (plaintext, sent over TLS)")
+    new_password: str = Field(..., min_length=8, max_length=256, description="New password (plaintext, sent over TLS)")
 
 # Serializes file-mode password changes and makes the server.conf rewrite
 # below atomic (temp file + os.replace instead of truncate-in-place), so a
@@ -337,6 +345,10 @@ async def change_password(request: ChangePasswordRequest, http_request: Request)
     if not username:
         raise HTTPException(status_code=401, detail="Not authenticated")
     if is_db_mode:
+        from common.util.password_util import validate_password_complexity
+        is_valid, reason = validate_password_complexity(request.new_password)
+        if not is_valid:
+            raise HTTPException(status_code=400, detail=f"Password does not meet complexity requirements: {reason}")
         from database.utils.user_store import authenticate_user, update_password
         # Verify old password
         user = authenticate_user(username, request.old_password)
@@ -347,15 +359,19 @@ async def change_password(request: ChangePasswordRequest, http_request: Request)
             logger.info(f"Password changed for user '{username}'")
             return ok(message="Password changed successfully")
         raise HTTPException(status_code=500, detail="Failed to change password")
-    # File mode: update access_password in server.conf
+    # File mode: update access_password in server.conf. Stored value is
+    # sha256(plaintext) (see generate_access_password.py); hash both the
+    # incoming old and new plaintext passwords the same way.
     stored = conf.get("access_password", "")
-    if not secrets.compare_digest(request.old_password, stored):
+    old_computed = hashlib.sha256(request.old_password.encode()).hexdigest()
+    if not secrets.compare_digest(old_computed, stored):
         raise HTTPException(status_code=401, detail="Current password is incorrect")
+    new_computed = hashlib.sha256(request.new_password.encode()).hexdigest()
     conf_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "etc", "conf", "server.conf")
     if not os.path.exists(conf_path):
         logger.error(f"Cannot change password: {conf_path} does not exist")
         raise HTTPException(status_code=500, detail="server.conf not found")
-    if _update_access_password_in_conf(conf_path, request.new_password):
+    if _update_access_password_in_conf(conf_path, new_computed):
         logger.info("Password changed (file mode): access_password updated in server.conf")
         return ok(message="Password changed successfully")
     logger.error(f"Cannot change password: no access_password key in {conf_path}")

--- a/orchestrate/start.py
+++ b/orchestrate/start.py
@@ -154,11 +154,10 @@ def main():
     is_enable_https = str(is_https).lower() == 'true'
     if server_config.get('persistence_mode', 'file').lower() != 'file':
         create_tables()
-        # Seed default admin user if users table is empty.
-        # The password stored is the SHA-256 hash, matching what the frontend sends.
-        import hashlib
-        default_pw_hash = hashlib.sha256(b"OpenAN@2026").hexdigest()
-        if seed_admin_if_empty(default_pw_hash):
+        # Seed default admin user if users table is empty. user_store now
+        # hashes the real plaintext password server-side (see #9), so this
+        # is passed as-is rather than pre-hashed.
+        if seed_admin_if_empty("OpenAN@2026"):
             logger.info("Default admin user 'admin' created; a password change is required on first login")
         else:
             logger.info("Users already exist, skipping admin seed")

--- a/tests/test_auth_server_side_hashing.py
+++ b/tests/test_auth_server_side_hashing.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import hashlib
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, Request
+from pydantic import ValidationError
+
+os.environ.setdefault("TESTING", "True")
+
+from orchestrate.server import frontend_support_server as srv
+
+
+def _http_request(token=None):
+    headers = []
+    if token:
+        headers.append((b"authorization", f"Bearer {token}".encode()))
+    scope = {"type": "http", "method": "POST", "path": "/x", "headers": headers, "query_string": b""}
+    return Request(scope)
+
+
+@pytest.mark.anyio
+class TestLoginFileMode:
+    """Regression coverage for #9a: frontend no longer pre-hashes; the
+    backend now hashes the plaintext it receives before comparing."""
+
+    async def test_correct_plaintext_password_succeeds(self, monkeypatch):
+        monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
+        stored_hash = hashlib.sha256(b"MyRealPassword1!").hexdigest()
+        monkeypatch.setattr(srv, "get_conf", lambda: {
+            "persistence_mode": "file", "access_password": stored_hash,
+        })
+        result = await srv.login(srv.LoginRequest(username="admin", password="MyRealPassword1!"))
+        assert result["data"]["token"] is not None
+
+    async def test_wrong_plaintext_password_rejected(self, monkeypatch):
+        monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
+        stored_hash = hashlib.sha256(b"MyRealPassword1!").hexdigest()
+        monkeypatch.setattr(srv, "get_conf", lambda: {
+            "persistence_mode": "file", "access_password": stored_hash,
+        })
+        with pytest.raises(HTTPException) as exc_info:
+            await srv.login(srv.LoginRequest(username="admin", password="wrong-password"))
+        assert exc_info.value.status_code == 401
+
+    async def test_previously_client_hashed_value_no_longer_works(self, monkeypatch):
+        """The old client-side sha256(password) digest must NOT authenticate
+        anymore -- that was exactly the pass-the-hash surface #9 closes."""
+        monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
+        stored_hash = hashlib.sha256(b"MyRealPassword1!").hexdigest()
+        monkeypatch.setattr(srv, "get_conf", lambda: {
+            "persistence_mode": "file", "access_password": stored_hash,
+        })
+        old_client_hash = hashlib.sha256(b"MyRealPassword1!").hexdigest()
+        with pytest.raises(HTTPException) as exc_info:
+            await srv.login(srv.LoginRequest(username="admin", password=old_client_hash))
+        assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+class TestRegisterComplexity:
+    async def test_rejects_password_with_single_character_type(self, monkeypatch):
+        monkeypatch.setattr(srv, "get_conf", lambda: {"persistence_mode": "postgresql"})
+        with pytest.raises(HTTPException) as exc_info:
+            await srv.register(srv.RegisterRequest(username="alice", password="aaaaaaaa"))
+        assert exc_info.value.status_code == 400
+        assert "complexity" in exc_info.value.detail.lower()
+
+    async def test_accepts_password_meeting_complexity(self, monkeypatch):
+        monkeypatch.setattr(srv, "get_conf", lambda: {"persistence_mode": "postgresql"})
+        with patch("database.utils.user_store.user_exists", return_value=False), \
+             patch("database.utils.user_store.create_user", return_value=True) as mock_create:
+            result = await srv.register(srv.RegisterRequest(username="alice", password="Str0ngPass"))
+            assert result["data"]["username"] == "alice"
+            mock_create.assert_called_once_with("alice", "Str0ngPass")
+
+    def test_too_short_password_rejected_at_the_model_layer(self):
+        with pytest.raises(ValidationError):
+            srv.RegisterRequest(username="alice", password="Ab1")
+
+
+@pytest.mark.anyio
+class TestChangePasswordDbMode:
+    async def test_rejects_weak_new_password(self, monkeypatch):
+        monkeypatch.setattr(srv, "get_conf", lambda: {"persistence_mode": "postgresql"})
+        store = srv.get_session_store()
+        token, _ = store.create("alice")
+        try:
+            request = srv.ChangePasswordRequest(old_password="OldPassw0rd!", new_password="aaaaaaaa")
+            with pytest.raises(HTTPException) as exc_info:
+                await srv.change_password(request, _http_request(token))
+            assert exc_info.value.status_code == 400
+        finally:
+            store.revoke(token)
+
+    async def test_accepts_strong_new_password(self, monkeypatch):
+        monkeypatch.setattr(srv, "get_conf", lambda: {"persistence_mode": "postgresql"})
+        store = srv.get_session_store()
+        token, _ = store.create("alice")
+        try:
+            request = srv.ChangePasswordRequest(old_password="OldPassw0rd!", new_password="NewStr0ngPass!")
+            with patch("database.utils.user_store.authenticate_user", return_value={"username": "alice", "role": "user"}), \
+                 patch("database.utils.user_store.update_password", return_value=True) as mock_update:
+                result = await srv.change_password(request, _http_request(token))
+                assert result["message"] == "Password changed successfully"
+                mock_update.assert_called_once_with("alice", "NewStr0ngPass!")
+        finally:
+            store.revoke(token)
+
+
+@pytest.mark.anyio
+class TestChangePasswordFileMode:
+    async def test_hashes_old_and_new_password_before_comparing_and_storing(self, monkeypatch, tmp_path):
+        old_hash = hashlib.sha256(b"OldPassw0rd!").hexdigest()
+        conf_path = tmp_path / "server.conf"
+        conf_path.write_text(f"access_password={old_hash}\n", encoding="utf-8")
+
+        monkeypatch.setattr(srv, "get_conf", lambda: {"persistence_mode": "file", "access_password": old_hash})
+        monkeypatch.setattr(srv.get_conf, "cache_clear", lambda: None, raising=False)
+
+        real_join = os.path.join
+
+        def _fake_join(*parts):
+            if parts[-3:] == ("etc", "conf", "server.conf"):
+                return str(conf_path)
+            return real_join(*parts)
+
+        store = srv.get_session_store()
+        token, _ = store.create("admin")
+        try:
+            request = srv.ChangePasswordRequest(old_password="OldPassw0rd!", new_password="NewPassw0rd!")
+            with patch.object(srv.os.path, "join", side_effect=_fake_join):
+                result = await srv.change_password(request, _http_request(token))
+            assert result["message"] == "Password changed successfully"
+            new_hash = hashlib.sha256(b"NewPassw0rd!").hexdigest()
+            assert conf_path.read_text(encoding="utf-8") == f"access_password={new_hash}\n"
+        finally:
+            store.revoke(token)
+
+    async def test_wrong_old_password_rejected(self, monkeypatch, tmp_path):
+        old_hash = hashlib.sha256(b"OldPassw0rd!").hexdigest()
+        monkeypatch.setattr(srv, "get_conf", lambda: {"persistence_mode": "file", "access_password": old_hash})
+
+        store = srv.get_session_store()
+        token, _ = store.create("admin")
+        try:
+            request = srv.ChangePasswordRequest(old_password="wrong", new_password="NewPassw0rd!")
+            with pytest.raises(HTTPException) as exc_info:
+                await srv.change_password(request, _http_request(token))
+            assert exc_info.value.status_code == 401
+        finally:
+            store.revoke(token)

--- a/tests/test_table_creation.py
+++ b/tests/test_table_creation.py
@@ -30,7 +30,14 @@ class TestCreateTables:
             queries = [call.args[1] for call in mock_exec.call_args_list]
             assert any("ADD COLUMN IF NOT EXISTS must_change_password" in q for q in queries)
 
-    def test_raises_when_migration_fails(self):
+    def test_runs_password_scheme_migration(self):
+        with patch.object(table_creation, "create_connection", return_value=MagicMock()), \
+             patch.object(table_creation, "execute_query", return_value=(None, None)) as mock_exec:
+            table_creation.create_tables()
+            queries = [call.args[1] for call in mock_exec.call_args_list]
+            assert any("ADD COLUMN IF NOT EXISTS password_scheme" in q for q in queries)
+
+    def test_raises_when_must_change_password_migration_fails(self):
         def _fake_execute(conn, query, *args, **kwargs):
             if "ALTER TABLE" in query and "must_change_password" in query:
                 return None, RuntimeError("boom")
@@ -38,7 +45,18 @@ class TestCreateTables:
 
         with patch.object(table_creation, "create_connection", return_value=MagicMock()), \
              patch.object(table_creation, "execute_query", side_effect=_fake_execute):
-            with pytest.raises(RuntimeError, match="Failed to migrate users table"):
+            with pytest.raises(RuntimeError, match="Failed to migrate users table \\(must_change_password\\)"):
+                table_creation.create_tables()
+
+    def test_raises_when_password_scheme_migration_fails(self):
+        def _fake_execute(conn, query, *args, **kwargs):
+            if "ALTER TABLE" in query and "password_scheme" in query:
+                return None, RuntimeError("boom")
+            return None, None
+
+        with patch.object(table_creation, "create_connection", return_value=MagicMock()), \
+             patch.object(table_creation, "execute_query", side_effect=_fake_execute):
+            with pytest.raises(RuntimeError, match="Failed to migrate users table \\(password_scheme\\)"):
                 table_creation.create_tables()
 
     def test_raises_when_no_connection(self):

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -15,6 +15,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import hashlib
 from unittest.mock import MagicMock, patch
 
 from database.utils import user_store
@@ -32,6 +33,7 @@ class TestCreateUser:
             params = mock_exec.call_args[0][2]
             assert params[3] == "user"
             assert params[4] is False
+            assert params[5] == "v2"
 
     def test_passes_through_role_and_must_change_password(self):
         with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
@@ -40,6 +42,17 @@ class TestCreateUser:
             params = mock_exec.call_args[0][2]
             assert params[3] == "admin"
             assert params[4] is True
+
+    def test_hashes_the_plaintext_directly(self):
+        """create_user's hash must match _hash_password(plaintext, salt) --
+        i.e. the real password, not some pre-hashed digest of it."""
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "_generate_salt", return_value="fixedsalt"), \
+             patch.object(user_store, "execute_query", return_value=(None, None)) as mock_exec:
+            user_store.create_user("alice", "S3cure!pw")
+            params = mock_exec.call_args[0][2]
+            expected = hashlib.sha256(b"fixedsalt:S3cure!pw").hexdigest()
+            assert params[1] == expected
 
     def test_returns_false_on_db_error(self):
         with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
@@ -51,16 +64,16 @@ class TestCreateUser:
             assert user_store.create_user("alice", "pw") is False
 
 
-class TestAuthenticateUser:
-    def _row_for(self, password, salt="salt123", role="user", must_change_password=False):
-        password_hash = user_store._hash_password(password, salt)
-        return ("alice", password_hash, salt, role, must_change_password)
+class TestAuthenticateUserV2Scheme:
+    def _row_for(self, plaintext, salt="salt123", role="user", must_change_password=False):
+        password_hash = user_store._hash_password(plaintext, salt)
+        return ("alice", password_hash, salt, role, must_change_password, "v2")
 
-    def test_returns_user_dict_on_correct_password(self):
-        row = self._row_for("correct-horse")
+    def test_correct_plaintext_authenticates(self):
+        row = self._row_for("S3cure!pw")
         with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
              patch.object(user_store, "execute_query", return_value=([row], None)):
-            result = user_store.authenticate_user("alice", "correct-horse")
+            result = user_store.authenticate_user("alice", "S3cure!pw")
             assert result == {"username": "alice", "role": "user", "must_change_password": False}
 
     def test_surfaces_must_change_password_true(self):
@@ -70,11 +83,19 @@ class TestAuthenticateUser:
             result = user_store.authenticate_user("alice", "OpenAN@2026")
             assert result["must_change_password"] is True
 
-    def test_returns_none_on_wrong_password(self):
-        row = self._row_for("correct-horse")
+    def test_wrong_plaintext_rejected(self):
+        row = self._row_for("S3cure!pw")
         with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
              patch.object(user_store, "execute_query", return_value=([row], None)):
             assert user_store.authenticate_user("alice", "wrong") is None
+
+    def test_does_not_trigger_scheme_upgrade(self):
+        row = self._row_for("S3cure!pw")
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)), \
+             patch.object(user_store, "_upgrade_password_scheme") as mock_upgrade:
+            user_store.authenticate_user("alice", "S3cure!pw")
+            mock_upgrade.assert_not_called()
 
     def test_returns_none_when_user_not_found(self):
         with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
@@ -82,31 +103,107 @@ class TestAuthenticateUser:
             assert user_store.authenticate_user("nobody", "pw") is None
 
 
-class TestUpdatePassword:
-    def test_clears_must_change_password_flag(self):
+class TestAuthenticateUserLegacyScheme:
+    def _legacy_row_for(self, plaintext, salt="salt123", role="user", must_change_password=False):
+        # This is exactly what the old client-side sha256() + old backend
+        # _hash_password(client_hash, salt) pipeline used to produce.
+        client_hash = hashlib.sha256(plaintext.encode()).hexdigest()
+        password_hash = user_store._hash_password(client_hash, salt)
+        return ("alice", password_hash, salt, role, must_change_password, "legacy")
+
+    def test_real_password_still_authenticates_without_reset(self):
+        row = self._legacy_row_for("MyRealPassword1!")
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)), \
+             patch.object(user_store, "_upgrade_password_scheme"):
+            result = user_store.authenticate_user("alice", "MyRealPassword1!")
+            assert result == {"username": "alice", "role": "user", "must_change_password": False}
+
+    def test_wrong_password_rejected(self):
+        row = self._legacy_row_for("MyRealPassword1!")
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)):
+            assert user_store.authenticate_user("alice", "wrong") is None
+
+    def test_successful_login_upgrades_scheme(self):
+        row = self._legacy_row_for("MyRealPassword1!")
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)), \
+             patch.object(user_store, "_upgrade_password_scheme") as mock_upgrade:
+            user_store.authenticate_user("alice", "MyRealPassword1!")
+            mock_upgrade.assert_called_once_with("alice", "MyRealPassword1!", "salt123")
+
+    def test_failed_login_does_not_upgrade_scheme(self):
+        row = self._legacy_row_for("MyRealPassword1!")
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)), \
+             patch.object(user_store, "_upgrade_password_scheme") as mock_upgrade:
+            user_store.authenticate_user("alice", "wrong")
+            mock_upgrade.assert_not_called()
+
+    def test_null_scheme_treated_as_legacy(self):
+        """Rows that existed before the password_scheme column was added
+        have NULL there -- must fall back to legacy verification."""
+        client_hash = hashlib.sha256("MyRealPassword1!".encode()).hexdigest()
+        password_hash = user_store._hash_password(client_hash, "salt123")
+        row = ("alice", password_hash, "salt123", "user", False, None)
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)), \
+             patch.object(user_store, "_upgrade_password_scheme"):
+            result = user_store.authenticate_user("alice", "MyRealPassword1!")
+            assert result == {"username": "alice", "role": "user", "must_change_password": False}
+
+    def test_preserves_must_change_password_through_upgrade(self):
+        row = self._legacy_row_for("OpenAN@2026", role="admin", must_change_password=True)
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([row], None)), \
+             patch.object(user_store, "_upgrade_password_scheme"):
+            result = user_store.authenticate_user("alice", "OpenAN@2026")
+            assert result["must_change_password"] is True
+
+
+class TestUpgradePasswordScheme:
+    def test_rehashes_under_current_scheme(self):
         with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
              patch.object(user_store, "execute_query", return_value=(None, None)) as mock_exec:
-            assert user_store.update_password("alice", "new-pw") is True
+            user_store._upgrade_password_scheme("alice", "MyRealPassword1!", "salt123")
             query = mock_exec.call_args[0][1]
+            params = mock_exec.call_args[0][2]
+            expected_hash = user_store._hash_password("MyRealPassword1!", "salt123")
+            assert "password_scheme" in query
+            assert "must_change_password" not in query
+            assert params[0] == expected_hash
+            assert params[1] == "v2"
+
+
+class TestUpdatePassword:
+    def test_stamps_current_scheme_and_clears_must_change_password(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, None)) as mock_exec:
+            assert user_store.update_password("alice", "NewPassw0rd!") is True
+            query = mock_exec.call_args[0][1]
+            params = mock_exec.call_args[0][2]
+            assert "password_scheme" in query
             assert "must_change_password = FALSE" in query
+            assert "v2" in params
 
     def test_returns_false_on_db_error(self):
         with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
              patch.object(user_store, "execute_query", return_value=(None, RuntimeError("boom"))):
-            assert user_store.update_password("alice", "new-pw") is False
+            assert user_store.update_password("alice", "NewPassw0rd!") is False
 
 
 class TestSeedAdminIfEmpty:
-    def test_creates_admin_flagged_must_change_password(self):
+    def test_passes_plaintext_through_and_flags_must_change_password(self):
         with patch.object(user_store, "has_any_user", return_value=False), \
              patch.object(user_store, "create_user", return_value=True) as mock_create:
-            assert user_store.seed_admin_if_empty("hashed-default") is True
-            mock_create.assert_called_once_with("admin", "hashed-default", "admin", must_change_password=True)
+            assert user_store.seed_admin_if_empty("OpenAN@2026") is True
+            mock_create.assert_called_once_with("admin", "OpenAN@2026", "admin", must_change_password=True)
 
     def test_no_op_when_users_already_exist(self):
         with patch.object(user_store, "has_any_user", return_value=True), \
              patch.object(user_store, "create_user") as mock_create:
-            assert user_store.seed_admin_if_empty("hashed-default") is False
+            assert user_store.seed_admin_if_empty("OpenAN@2026") is False
             mock_create.assert_not_called()
 
 

--- a/workflow-designer/src/service/api.js
+++ b/workflow-designer/src/service/api.js
@@ -260,15 +260,8 @@ export async function authCheck() {
     return resp.data;
 }
  
-async function sha256(text) {
-    const data = new TextEncoder().encode(text);
-    const hash = await crypto.subtle.digest('SHA-256', data);
-    return Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2, '0')).join('');
-}
-
 export async function login(username, password) {
-    const hashed = await sha256(password);
-    const body = await api.post(`${ORCHESTRATE_BASE()}/auth/login`, { username, password: hashed });
+    const body = await api.post(`${ORCHESTRATE_BASE()}/auth/login`, { username, password });
     if (body.data && body.data.token) {
          setAuthToken(body.data.token);
      }
@@ -284,8 +277,7 @@ export async function logout() {
 }
  
 export async function register(username, password) {
-    const hashed = await sha256(password);
-    const body = await api.post(`${ORCHESTRATE_BASE()}/auth/register`, { username, password: hashed });
+    const body = await api.post(`${ORCHESTRATE_BASE()}/auth/register`, { username, password });
     return body.data;
 }
  
@@ -299,10 +291,8 @@ export async function deleteUser(username) {
 }
 
 export async function changePassword(oldPassword, newPassword) {
-    const oldHash = await sha256(oldPassword);
-    const newHash = await sha256(newPassword);
     return api.post(`${ORCHESTRATE_BASE()}/auth/change-password`, {
-        old_password: oldHash,
-        new_password: newHash,
+        old_password: oldPassword,
+        new_password: newPassword,
     });
 }


### PR DESCRIPTION
## Description

`workflow-designer/src/service/api.js` hashed the password with SHA-256 client-side (`crypto.subtle`) before it was ever sent to the backend. That digest was fixed, un-salted, and un-nonced from the wire's perspective — anyone who captured it once (network sniff, XSS, browser devtools/history, a proxy or access log) could replay it as the password indefinitely: a permanent pass-the-hash. It also meant the backend could never validate real password complexity server-side — it only ever saw a 64-character lowercase-hex string, never the actual password, despite the README and the register UI both claiming an uppercase/lowercase/digit complexity policy that only existed client-side and was trivially bypassable by calling the API directly:

```
POST /rest/v1/orchestrate/auth/register {"username":"attacker1","password":"abc123"}
```

This is the first half (**9a**) of a two-part split proposed on hw-irc-sni/orchestration-center#9. It closes the pass-the-hash replay and makes the documented password policy real. The second half (**9b** — moving the session token from `localStorage` to an httpOnly cookie) is a separate, independent follow-up.

## What changed

- `api.js` no longer pre-hashes. `login`/`register`/`changePassword` now send the real password. **This relies on `enable_https=true` for confidentiality in transit** — documented in `README.md`/`README_zh.md`, which previously didn't call this out at all.
- Passwords are hashed server-side:
  - DB mode: unchanged formula (`_hash_password(password, per-user salt)` = salted SHA-256), just now applied to the real plaintext instead of the client's digest of it.
  - File mode: the backend hashes the incoming plaintext with SHA-256 before comparing to `access_password`, which already stored `sha256(plaintext)` via `generate_access_password.py` — that config format and generator script are unchanged.
- `POST /auth/register` and the DB-mode branch of `POST /auth/change-password` now call `common/util/password_util.validate_password_complexity`, which existed with zero callers outside its own CLI tooling before this. This is what actually makes the documented policy enforceable — the server previously never saw a plaintext password, so it structurally could not evaluate complexity. Also corrected `README.md`'s description of the policy to match what's now actually enforced (8+ chars, at least 2 of {digit, upper, lower, special} — not the stricter "uppercase, lowercase, and a number" it used to claim, which nothing ever checked server-side).

## Backward compatibility — no forced reset

Any KDF change here invalidates every stored `password_hash`, since existing DB-mode rows were computed from the client's own SHA-256 pre-hash of the password, not the real plaintext — the meaning of what's being hashed changes even though the hash function (salted SHA-256) doesn't.

Rather than a forced password reset for every existing user, added a `password_scheme` column (`'legacy'` for existing rows via migration, `'v2'` for new ones). `authenticate_user()` detects `'legacy'` rows and reconstructs the same client-side digest server-side from the plaintext it now receives — since that digest is a pure function of the password, this reproduces exactly what the old client used to compute — so existing accounts keep working with the password their owner already knows. A successful legacy login opportunistically upgrades the row to `'v2'`. No admin action required, no locked-out users, no migration script to run by hand.

## Deliberately out of scope

- **9b** — httpOnly session cookie migration. Tracked as its own follow-up on hw-irc-sni/orchestration-center#9.
- **KDF strengthening** — the hash function itself stays single-round salted SHA-256; only what gets hashed changes (real plaintext instead of a pre-hash). A stronger KDF (e.g. PBKDF2) against a stolen table is a separate, orthogonal improvement not required to close this issue's pass-the-hash finding.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change) — see "Backward compatibility" above for why this is not actually breaking for existing users
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header — no new source files (only new test files, which do carry the header)

## Additional Context

Validated locally:
- `pytest tests/ --ignore=tests/test_external_apis.py` — 360 passed, 7 pre-existing skips, 0 failures. 30 new tests: `tests/test_user_store.py` (17, including the legacy-scheme reconstruction and opportunistic-upgrade behavior), `tests/test_table_creation.py` (3, the migration), `tests/test_auth_server_side_hashing.py` (10, endpoint-level: file-mode hashing both directions, register/change-password complexity enforcement, and an explicit regression test that the *old* client-side hash no longer authenticates).
- `npm run lint` — 0 errors, 31 warnings (unchanged baseline).
- `npm run build` — succeeds.
- `npm run test` — 27/27 passed (pre-existing suite, unaffected — `api.test.js` doesn't cover login/register/changePassword).

**Dependency note:** hw-irc-sni/orchestration-center#12 (project-openan/orchestration-center#59, not yet merged) also migrates this same `users` table (adds `must_change_password`). The two migrations are independent and don't conflict semantically (`ADD COLUMN IF NOT EXISTS` for two different columns), but whichever of #59 / this PR merges second will need a routine rebase over the other's `table_creation.py`/`user_store.py` changes — flagging per the sequencing discussion on hw-irc-sni/orchestration-center#37 (#12 was recommended to land before this one).

One of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37. Sixth in the recommended sequence (#7 → #8 → #13 → #12 → #14 → #9 → #16) — by far the widest blast radius of the set, which is why it's split and lands late.
