### PR TITLE
test: cover the authentication/user-management/certificate surface

### DIFF
--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Regression coverage for #16: the base _SessionStore and auth_middleware
+behavior had no direct tests -- only higher-level features built on top of
+them (admin gate, forced password change, server-side hashing) were tested,
+each exercising just the slice of this surface it needed.
+"""
+
+import time
+
+import pytest
+from fastapi import Request
+from fastapi.responses import PlainTextResponse
+
+from orchestrate.server import auth as auth_module
+from orchestrate.server.auth import _SessionStore, auth_middleware, _PUBLIC_AUTH_PATHS
+
+
+def _make_request(path, token=None, method="GET", as_query_param=False):
+    headers = []
+    query_string = b""
+    if token:
+        if as_query_param:
+            query_string = f"access_token={token}".encode()
+        else:
+            headers.append((b"authorization", f"Bearer {token}".encode()))
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": headers,
+        "query_string": query_string,
+    }
+    return Request(scope)
+
+
+async def _call_next(request):
+    return PlainTextResponse("ok")
+
+
+class TestSessionStoreLifecycle:
+    def test_create_returns_unique_tokens(self):
+        store = _SessionStore()
+        token1, _ = store.create("alice")
+        token2, _ = store.create("alice")
+        assert token1 != token2
+
+    def test_validate_true_for_fresh_token(self):
+        store = _SessionStore()
+        token, _ = store.create("alice")
+        assert store.validate(token) is True
+
+    def test_validate_false_for_unknown_token(self):
+        store = _SessionStore()
+        assert store.validate("does-not-exist") is False
+
+    def test_validate_false_for_empty_token(self):
+        store = _SessionStore()
+        assert store.validate("") is False
+        assert store.validate(None) is False
+
+    def test_validate_false_and_evicts_expired_token(self):
+        store = _SessionStore()
+        token, _ = store.create("alice")
+        username, role, _ = store._tokens[token]
+        store._tokens[token] = (username, role, time.time() - 1)
+        assert store.validate(token) is False
+        assert token not in store._tokens
+
+    def test_get_username_returns_username_for_valid_token(self):
+        store = _SessionStore()
+        token, _ = store.create("alice")
+        assert store.get_username(token) == "alice"
+
+    def test_get_username_none_for_unknown_token(self):
+        store = _SessionStore()
+        assert store.get_username("does-not-exist") is None
+
+    def test_get_username_none_for_empty_token(self):
+        store = _SessionStore()
+        assert store.get_username("") is None
+
+    def test_revoke_removes_the_token(self):
+        store = _SessionStore()
+        token, _ = store.create("alice")
+        store.revoke(token)
+        assert store.validate(token) is False
+        assert store.get_username(token) is None
+
+    def test_revoke_unknown_token_is_a_no_op(self):
+        store = _SessionStore()
+        store.revoke("does-not-exist")  # must not raise
+
+
+class TestPublicAuthPaths:
+    def test_login_check_register_are_public(self):
+        assert _PUBLIC_AUTH_PATHS == {
+            "/rest/v1/orchestrate/auth/login",
+            "/rest/v1/orchestrate/auth/check",
+            "/rest/v1/orchestrate/auth/register",
+        }
+
+
+@pytest.mark.anyio
+class TestAuthMiddleware:
+    async def test_options_preflight_always_allowed(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        request = _make_request("/rest/v1/orchestrate/workflows", method="OPTIONS")
+        response = await auth_middleware(request, _call_next)
+        assert response.status_code == 200
+
+    async def test_external_api_paths_bypass_token_auth(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        request = _make_request("/api/v1/orchestrate/sop")
+        response = await auth_middleware(request, _call_next)
+        assert response.status_code == 200
+
+    async def test_bypasses_entirely_when_auth_disabled(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: False)
+        request = _make_request("/rest/v1/orchestrate/workflows")
+        response = await auth_middleware(request, _call_next)
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("path", sorted(_PUBLIC_AUTH_PATHS))
+    async def test_public_auth_paths_bypass_without_a_token(self, monkeypatch, path):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        request = _make_request(path)
+        response = await auth_middleware(request, _call_next)
+        assert response.status_code == 200
+
+    async def test_missing_token_on_protected_path_is_401(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        request = _make_request("/rest/v1/orchestrate/workflows")
+        response = await auth_middleware(request, _call_next)
+        assert response.status_code == 401
+
+    async def test_invalid_token_on_protected_path_is_401(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        request = _make_request("/rest/v1/orchestrate/workflows", token="not-a-real-token")
+        response = await auth_middleware(request, _call_next)
+        assert response.status_code == 401
+
+    async def test_valid_token_on_protected_path_passes_through(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        store = auth_module.get_session_store()
+        token, _ = store.create("alice")
+        try:
+            request = _make_request("/rest/v1/orchestrate/workflows", token=token)
+            response = await auth_middleware(request, _call_next)
+            assert response.status_code == 200
+        finally:
+            store.revoke(token)
+
+    async def test_valid_token_via_query_param_passes_through(self, monkeypatch):
+        """SSE/EventSource can't set headers, so the token may arrive as
+        ?access_token=... instead of an Authorization header."""
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        store = auth_module.get_session_store()
+        token, _ = store.create("alice")
+        try:
+            request = _make_request("/rest/v1/orchestrate/workflows", token=token, as_query_param=True)
+            response = await auth_middleware(request, _call_next)
+            assert response.status_code == 200
+        finally:
+            store.revoke(token)

--- a/tests/test_certificate_generator.py
+++ b/tests/test_certificate_generator.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Regression coverage for #16: certificate_generator.py and
+password_generator.py had zero automated tests despite being the code that
+produces the server's self-signed TLS certificate and its private-key
+password on every fresh HTTPS-enabled deployment.
+"""
+
+import os
+
+import pytest
+
+from common.cert.certificate_generator import CertificateGenerator
+from common.cert.password_generator import PasswordGenerator
+
+
+class TestPasswordGenerator:
+    def test_default_length_is_sixteen(self):
+        gen = PasswordGenerator()
+        assert len(gen.generate_password()) == 16
+
+    def test_respects_custom_length(self):
+        gen = PasswordGenerator()
+        assert len(gen.generate_password(24)) == 24
+
+    def test_raises_for_length_below_eight(self):
+        gen = PasswordGenerator()
+        with pytest.raises(ValueError, match="at least 8"):
+            gen.generate_password(7)
+
+    def test_contains_all_four_character_classes(self):
+        """The generator seeds one character from each of digit/upper/lower/
+        special into the first four (pre-shuffle) slots, so this must hold
+        for every generated password regardless of RNG -- not just often."""
+        gen = PasswordGenerator()
+        for _ in range(50):
+            password = gen.generate_password(16)
+            assert any(c in PasswordGenerator.DIGITS for c in password)
+            assert any(c in PasswordGenerator.UPPER for c in password)
+            assert any(c in PasswordGenerator.LOWER for c in password)
+            assert any(c in PasswordGenerator.SPECIAL for c in password)
+
+    def test_passwords_are_not_all_identical(self):
+        gen = PasswordGenerator()
+        passwords = {gen.generate_password(16) for _ in range(20)}
+        assert len(passwords) > 1
+
+
+class TestCertificateGeneratorLegacyApi:
+    def test_generates_cert_key_and_password_files(self, tmp_path):
+        cert_dir = str(tmp_path / "certs")
+        gen = CertificateGenerator()
+        assert gen.generate_certificates(cert_dir, ["serverAuth"]) is True
+        assert os.path.exists(os.path.join(cert_dir, CertificateGenerator.CERT_FILE))
+        assert os.path.exists(os.path.join(cert_dir, CertificateGenerator.KEY_FILE))
+        assert os.path.exists(os.path.join(cert_dir, CertificateGenerator.PWD_FILE))
+
+    def test_returns_false_without_overwriting_existing_certificates(self, tmp_path):
+        cert_dir = str(tmp_path / "certs")
+        gen = CertificateGenerator()
+        assert gen.generate_certificates(cert_dir, ["serverAuth"]) is True
+        cert_path = os.path.join(cert_dir, CertificateGenerator.CERT_FILE)
+        original_contents = open(cert_path, "rb").read()
+
+        assert gen.generate_certificates(cert_dir, ["serverAuth"]) is False
+        assert open(cert_path, "rb").read() == original_contents
+
+    def test_creates_cert_dir_if_missing(self, tmp_path):
+        cert_dir = str(tmp_path / "nested" / "certs")
+        gen = CertificateGenerator()
+        assert gen.generate_certificates(cert_dir, ["serverAuth"]) is True
+        assert os.path.isdir(cert_dir)
+
+    def test_returns_false_for_unsupported_key_algorithm(self, tmp_path):
+        gen = CertificateGenerator(key_algorithm="DSA")
+        assert gen.generate_certificates(str(tmp_path / "certs"), ["serverAuth"]) is False
+
+
+class TestCertificateGeneratorSelfSignedApi:
+    def test_generates_cert_and_key_with_provided_password(self, tmp_path):
+        cert_dir = str(tmp_path / "certs")
+        gen = CertificateGenerator()
+        assert gen.generate_self_signed_cert(cert_dir, "serverAuth", "S3cure!Pass") is True
+        assert os.path.exists(os.path.join(cert_dir, "server_RSA.cer"))
+        assert os.path.exists(os.path.join(cert_dir, "server_key_RSA.pem"))
+
+    def test_returns_false_for_empty_password(self, tmp_path):
+        cert_dir = str(tmp_path / "certs")
+        gen = CertificateGenerator()
+        assert gen.generate_self_signed_cert(cert_dir, "serverAuth", "") is False
+        # cert_dir itself is created before the password is validated; no
+        # cert/key files are written since generation aborts before that.
+        assert not os.path.exists(os.path.join(cert_dir, "server_RSA.cer"))
+        assert not os.path.exists(os.path.join(cert_dir, "server_key_RSA.pem"))
+
+    def test_returns_false_without_overwriting_existing_certificates(self, tmp_path):
+        cert_dir = str(tmp_path / "certs")
+        gen = CertificateGenerator()
+        assert gen.generate_self_signed_cert(cert_dir, "serverAuth", "S3cure!Pass") is True
+        key_path = os.path.join(cert_dir, "server_key_RSA.pem")
+        original_contents = open(key_path, "rb").read()
+
+        assert gen.generate_self_signed_cert(cert_dir, "serverAuth", "AnotherPass1!") is False
+        assert open(key_path, "rb").read() == original_contents

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -217,3 +217,68 @@ class TestListUsers:
                 "username": "alice", "role": "admin",
                 "must_change_password": True, "created_at": "2026-01-01 00:00:00",
             }]
+
+
+class TestDeleteUser:
+    def test_returns_true_on_success(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, None)) as mock_exec:
+            assert user_store.delete_user("alice") is True
+            query = mock_exec.call_args[0][1]
+            params = mock_exec.call_args[0][2]
+            assert "DELETE FROM users" in query
+            assert params == ("alice",)
+
+    def test_returns_false_on_db_error(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, RuntimeError("boom"))):
+            assert user_store.delete_user("alice") is False
+
+    def test_returns_false_when_no_connection(self):
+        with patch.object(user_store, "create_connection", return_value=None):
+            assert user_store.delete_user("alice") is False
+
+
+class TestHasAnyUser:
+    def test_true_when_a_row_exists(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([(1,)], None)):
+            assert user_store.has_any_user() is True
+
+    def test_false_when_table_is_empty(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=([], None)):
+            assert user_store.has_any_user() is False
+
+    def test_false_on_db_error(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, RuntimeError("boom"))):
+            assert user_store.has_any_user() is False
+
+    def test_false_when_no_connection(self):
+        with patch.object(user_store, "create_connection", return_value=None):
+            assert user_store.has_any_user() is False
+
+
+class TestSaltUniqueness:
+    def test_generate_salt_does_not_repeat(self):
+        salts = {user_store._generate_salt() for _ in range(1000)}
+        assert len(salts) == 1000
+
+    def test_same_password_hashes_differently_per_user(self):
+        """Two users who happen to pick the same password must not end up
+        with the same password_hash -- that would let a stolen hash for one
+        account fingerprint every other account sharing that password."""
+        captured_hashes = []
+
+        def _capture(conn, query, params):
+            captured_hashes.append(params[1])  # password_hash
+            return None, None
+
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", side_effect=_capture):
+            user_store.create_user("alice", "SamePassw0rd!")
+            user_store.create_user("bob", "SamePassw0rd!")
+
+        assert len(captured_hashes) == 2
+        assert captured_hashes[0] != captured_hashes[1]

--- a/workflow-designer/src/service/api.test.js
+++ b/workflow-designer/src/service/api.test.js
@@ -36,7 +36,16 @@ import {
   matchWorkflows,
   getExecutionRecords,
   getExecutionRecord,
-  deleteExecutionRecord
+  deleteExecutionRecord,
+  getAuthToken,
+  setAuthToken,
+  authCheck,
+  login,
+  logout,
+  register,
+  listUsers,
+  deleteUser,
+  changePassword
 } from './api';
 
 // Mock axios
@@ -350,6 +359,166 @@ describe('api service', () => {
       const url2 = getStartProcessStreamUrl('psop-456', 'test intent with spaces');
       expect(url2).toContain('/rest/v1/orchestrate/execute?psop_id=psop-456');
       expect(url2).toContain('user_intent=');
+    });
+  });
+
+  // Regression coverage for #16: this file previously had zero tests for
+  // login/register/changePassword or the two axios interceptors, despite
+  // #9 (9a) changing exactly what these functions send over the wire.
+  describe('Access authentication', () => {
+    // Interceptors are registered once, at module import time -- before any
+    // beforeEach in this suite runs and calls vi.clearAllMocks(). Capture
+    // the real callbacks here, during test collection, not inside an it().
+    const mockApi = axios.create();
+    const requestInterceptor = mockApi.interceptors.request.use.mock.calls[0][0];
+    const [responseSuccessInterceptor, responseErrorInterceptor] = mockApi.interceptors.response.use.mock.calls[0];
+
+    describe('token storage', () => {
+      it('getAuthToken reads what setAuthToken wrote', () => {
+        setAuthToken('my-token');
+        expect(getAuthToken()).toBe('my-token');
+      });
+
+      it('setAuthToken(null) clears the stored token', () => {
+        setAuthToken('my-token');
+        setAuthToken(null);
+        expect(getAuthToken()).toBeNull();
+      });
+    });
+
+    describe('request interceptor', () => {
+      it('injects Authorization when a token is stored', () => {
+        setAuthToken('my-token');
+        const config = requestInterceptor({ headers: {} });
+        expect(config.headers.Authorization).toBe('Bearer my-token');
+      });
+
+      it('leaves Authorization unset when no token is stored', () => {
+        setAuthToken(null);
+        const config = requestInterceptor({ headers: {} });
+        expect(config.headers.Authorization).toBeUndefined();
+      });
+    });
+
+    describe('response interceptor', () => {
+      it('unwraps response.data on success', () => {
+        const result = responseSuccessInterceptor({ data: { status: 'success' } });
+        expect(result).toEqual({ status: 'success' });
+      });
+
+      it('clears the token and dispatches auth-expired on a 401', async () => {
+        setAuthToken('my-token');
+        const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+        const error = { response: { status: 401 } };
+
+        await expect(responseErrorInterceptor(error)).rejects.toBe(error);
+        expect(getAuthToken()).toBeNull();
+        expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'auth-expired' }));
+        dispatchSpy.mockRestore();
+      });
+
+      it('leaves the token alone on a non-401 error', async () => {
+        setAuthToken('my-token');
+        const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+        const error = { response: { status: 500 } };
+
+        await expect(responseErrorInterceptor(error)).rejects.toBe(error);
+        expect(getAuthToken()).toBe('my-token');
+        expect(dispatchSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'auth-expired' }));
+        dispatchSpy.mockRestore();
+      });
+
+      it('leaves the token alone on a network error with no response', async () => {
+        const error = {};
+        await expect(responseErrorInterceptor(error)).rejects.toBe(error);
+        // Must not throw on error.response being undefined.
+      });
+    });
+
+    describe('login/register/changePassword send plaintext (regression for #9)', () => {
+      it('login sends the password as-is, not a SHA-256 digest of it', async () => {
+        mockApi.post.mockResolvedValue({ data: { token: 'abc123', username: 'alice', role: 'user' } });
+
+        await login('alice', 'MyRealPassword1!');
+        expect(mockApi.post).toHaveBeenCalledWith(
+          expect.stringContaining('/auth/login'),
+          { username: 'alice', password: 'MyRealPassword1!' }
+        );
+      });
+
+      it('login stores the returned token', async () => {
+        mockApi.post.mockResolvedValue({ data: { token: 'abc123', username: 'alice', role: 'user' } });
+
+        await login('alice', 'MyRealPassword1!');
+        expect(getAuthToken()).toBe('abc123');
+      });
+
+      it('login does not store a token when auth is disabled', async () => {
+        mockApi.post.mockResolvedValue({ data: { auth_required: false, token: null } });
+
+        setAuthToken(null);
+        await login('alice', 'anything');
+        expect(getAuthToken()).toBeNull();
+      });
+
+      it('register sends the password as-is, not a SHA-256 digest of it', async () => {
+        mockApi.post.mockResolvedValue({ data: { username: 'alice' } });
+
+        await register('alice', 'MyRealPassword1!');
+        expect(mockApi.post).toHaveBeenCalledWith(
+          expect.stringContaining('/auth/register'),
+          { username: 'alice', password: 'MyRealPassword1!' }
+        );
+      });
+
+      it('changePassword sends both passwords as-is, not SHA-256 digests', async () => {
+        mockApi.post.mockResolvedValue({ data: {} });
+
+        await changePassword('OldPassword1!', 'NewPassword1!');
+        expect(mockApi.post).toHaveBeenCalledWith(
+          expect.stringContaining('/auth/change-password'),
+          { old_password: 'OldPassword1!', new_password: 'NewPassword1!' }
+        );
+      });
+    });
+
+    describe('other auth endpoints', () => {
+      it('authCheck calls GET /auth/check', async () => {
+        mockApi.get.mockResolvedValue({ data: { authenticated: false } });
+        const result = await authCheck();
+        expect(mockApi.get).toHaveBeenCalledWith(expect.stringContaining('/auth/check'));
+        expect(result).toEqual({ authenticated: false });
+      });
+
+      it('logout posts to /auth/logout and clears the token', async () => {
+        setAuthToken('my-token');
+        mockApi.post.mockResolvedValue({ data: {} });
+
+        await logout();
+        expect(mockApi.post).toHaveBeenCalledWith(expect.stringContaining('/auth/logout'));
+        expect(getAuthToken()).toBeNull();
+      });
+
+      it('logout clears the token even if the request fails', async () => {
+        setAuthToken('my-token');
+        mockApi.post.mockRejectedValue(new Error('network error'));
+
+        await expect(logout()).rejects.toThrow('network error');
+        expect(getAuthToken()).toBeNull();
+      });
+
+      it('listUsers calls GET /auth/users', async () => {
+        mockApi.get.mockResolvedValue({ data: [{ username: 'alice' }] });
+        const result = await listUsers();
+        expect(mockApi.get).toHaveBeenCalledWith(expect.stringContaining('/auth/users'));
+        expect(result).toEqual([{ username: 'alice' }]);
+      });
+
+      it('deleteUser calls DELETE /auth/users/{username}', async () => {
+        mockApi.delete.mockResolvedValue({ data: {} });
+        await deleteUser('alice');
+        expect(mockApi.delete).toHaveBeenCalledWith(expect.stringContaining('/auth/users/alice'));
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

The original security-authentication PR introduced ~800+ lines across `orchestrate/server/auth.py`, `database/utils/user_store.py`, `common/cert/certificate_generator.py`, `common/cert/password_generator.py`, and the auth functions in `workflow-designer/src/service/api.js` — with zero automated tests for any of it. The six fixes since (#7, #8, #12, #13, #14, and 9a of #9 — hw-irc-sni/orchestration-center#37) each added tests for the specific slice they touched, but the base primitives underneath were still never directly exercised: `_SessionStore`'s core lifecycle, `auth_middleware`'s public-path/401 behavior, several `user_store` functions, the certificate/password generators, and the entire frontend auth surface in `api.js`.

## What's covered

- **`tests/test_auth_middleware.py`** (new) — `_SessionStore.create/validate/get_username/revoke`, including expiry eviction and unknown/empty tokens; `auth_middleware`'s OPTIONS-preflight bypass, external-API (`/api/v1/*`) bypass, auth-disabled bypass, public-path (`login`/`check`/`register`) bypass, and 401 on a missing or invalid token vs. pass-through on a valid one — tested with both header and query-param token delivery, since SSE/`EventSource` can only use the latter.
- **`tests/test_user_store.py`** — added `delete_user`, `has_any_user`, and salt-uniqueness coverage: two users who pick the same password must not end up with the same `password_hash`, or a stolen hash for one account would fingerprint every other account sharing that password.
- **`tests/test_certificate_generator.py`** (new) — `PasswordGenerator`'s length bounds and guaranteed character-class coverage (the generator seeds one char from each of digit/upper/lower/special before shuffling, so this holds deterministically, not just probabilistically); `CertificateGenerator`'s legacy and self-signed APIs, including the no-clobber behavior when certificates already exist and the empty-password rejection path (found while writing this: the cert directory is created *before* the password is validated, so an empty-password call leaves an empty directory behind rather than nothing at all — documented in the test, not changed, since altering that ordering is out of scope here).
- **`workflow-designer/src/service/api.test.js`** — the request interceptor (`Authorization` header injection), the response interceptor (401 clears the token and dispatches `auth-expired`; other errors don't touch either), token storage, and `login`/`register`/`changePassword`/`authCheck`/`logout`/`listUsers`/`deleteUser` — including an explicit regression test that `login`/`register`/`changePassword` send the real password over the wire, not a SHA-256 digest of it (the frontend half of 9a's fix, previously untested on either side).

## Deliberately out of scope

The issue's own suggested coverage list includes "once #7 is fixed, a test asserting non-admin tokens are rejected by `/auth/users`." That test already exists — `tests/test_auth_admin_gate.py::TestRequireAdmin`, added when #7 landed, calls `require_admin()` directly with admin/non-admin/missing/invalid tokens. FastAPI's `Depends(require_admin)` just calls that same function with the request, so a route-level `TestClient` test would exercise identical logic; not duplicating it here.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Other (describe below) — test coverage only, no production code changed

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

Validated locally:
- `pytest tests/ --ignore=tests/test_external_apis.py` — 438 passed, 7 pre-existing skips, 0 failures. 43 new backend tests (21 in `test_auth_middleware.py`, 10 added to `test_user_store.py`, 12 in `test_certificate_generator.py`).
- `npm run test` — 45/45 passed (27 pre-existing + 18 new in `api.test.js`).
- `npm run lint` — 0 errors, 31 warnings (unchanged baseline).
- `npm run build` — succeeds.

Last item in the recommended sequence for hw-irc-sni/orchestration-center#37 (#7 → #8 → #13 → #12 → #14 → #9 → #16) — written against the post-fix surface as the issue itself requested, now that 9a has landed. Independent of every other PR in this set; applies cleanly against `main` on its own.
