### PR TITLE
fix: extract request text from nested request field for markdown rendering

### DIFF
--- a/workflow-designer/src/components/execution_center/timeline/index.jsx
+++ b/workflow-designer/src/components/execution_center/timeline/index.jsx
@@ -220,7 +220,7 @@ const ProtocolCard = React.memo(({ direction, data, timestamp, isDark }) => {
 
     const isRequest = direction === 'request';
     const raw = isRequest ? data.request : data.response;
-    const text = typeof raw === 'string' ? raw : (raw?.text || raw?.response || JSON.stringify(raw, null, 2));
+    const text = typeof raw === 'string' ? raw : (raw?.text || raw?.request || raw?.response || JSON.stringify(raw, null, 2));
     const metadata = data.metadata || {};
     const hasMetadata = Object.keys(metadata).length > 0;
     const state = data.state || data.task_state;


### PR DESCRIPTION
Closes #65

ProtocolCard displays raw JSON instead of rendered markdown for REQUEST cards because the text extraction chain misses the nested `request` field.

Fix: add `raw?.request` to the text extraction fallback chain in ProtocolCard.