### PR TITLE
fix: restore the secure verify_client default

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ python generate_access_password.py
 | Config Key | Description |
 |------------|-------------|
 | `enable_https` | Enable HTTPS for the backend server. |
-| `verify_client` | Require client certificate (mTLS). |
+| `verify_client` | Require client certificate (mTLS). Defaults to required when unset or set to anything other than the literal `false`; only an explicit `verify_client=false` in `server.conf` disables it. |
 | `ssl_certfile` | Server certificate path. |
 | `ssl_keyfile` | Server private key path (encrypted). |
 | `ssl_ca_certs` | CA trust store for verifying client certificates. |
@@ -405,7 +405,9 @@ python generate_selfsign_cert.py etc/ssl serverAuth
 2. Update `etc/conf/server.conf`:
    ```ini
    enable_https=true
-   verify_client=false          # set to true for mTLS (requires client certs)
+   verify_client=true           # mTLS -- clients must present a certificate. Set to
+                                 # false only if you understand this leaves the
+                                 # external API (see below) with no authentication.
    agent_registry_url=https://127.0.0.1:5000   # if registry center also uses HTTPS
    ```
 
@@ -422,6 +424,8 @@ python generate_selfsign_cert.py etc/ssl serverAuth
 ### External API Protection
 
 The external API (`/api/v1/*`) is protected by mTLS at the TLS layer when `enable_https=true` and `verify_client=true`. Clients must present a valid certificate during the TLS handshake -- no application-layer check needed.
+
+**With the shipped `enable_https=false` default, the external API has no protection at all** -- no mTLS (there's no TLS layer to begin with) and no application-layer check (`auth_middleware` only guards the internal API, `/rest/v1/orchestrate/*`, by design). Anything reachable on the network can call it. Don't expose a default (HTTP) deployment beyond local development without a reverse proxy, firewall, or network policy in front of it -- and once you do enable HTTPS, leave `verify_client` at its secure default (`true`) unless you have another authentication layer in place.
 
 ### Auth Endpoints
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -307,7 +307,7 @@ python generate_access_password.py
 | 配置项 | 说明 |
 |--------|------|
 | `enable_https` | 启用 HTTPS。 |
-| `verify_client` | 要求客户端证书（mTLS 双向认证）。 |
+| `verify_client` | 要求客户端证书（mTLS 双向认证）。未设置或设置为除字面量 `false` 以外的任何值时，默认要求证书；只有 `server.conf` 中显式写明 `verify_client=false` 才会关闭校验。 |
 | `ssl_certfile` | 服务器证书路径。 |
 | `ssl_keyfile` | 服务器私钥路径（加密存储）。 |
 | `ssl_ca_certs` | CA 信任库，用于校验客户端证书。 |
@@ -332,7 +332,8 @@ python generate_selfsign_cert.py etc/ssl serverAuth
 2. 修改 `etc/conf/server.conf`：
    ```ini
    enable_https=true
-   verify_client=false          # 设为 true 启用 mTLS（需客户端证书）
+   verify_client=true           # mTLS：要求客户端出示证书。仅在你清楚这会让
+                                 # 外部 API（见下文）完全没有认证保护时才设为 false
    agent_registry_url=https://127.0.0.1:5000   # 如果注册中心也用了 HTTPS
    ```
 
@@ -349,6 +350,8 @@ python generate_selfsign_cert.py etc/ssl serverAuth
 ### 外部 API 保护
 
 外部 API（`/api/v1/*`）在 `enable_https=true` 且 `verify_client=true` 时受 mTLS 保护。客户端必须在 TLS 握手阶段出示有效证书，无需应用层额外检查。
+
+**使用默认的 `enable_https=false` 时，外部 API 完全没有保护**——既没有 mTLS（根本不存在 TLS 层），也没有应用层检查（`auth_middleware` 按设计只保护内部 API `/rest/v1/orchestrate/*`）。网络可达的任何请求方都能调用它。除本地开发外，不要在没有反向代理、防火墙或网络策略保护的情况下暴露默认（HTTP）部署；一旦启用 HTTPS，除非你另有应用层认证机制，否则应保持 `verify_client` 处于安全默认值（`true`）。
 
 ### 认证接口
 

--- a/etc/conf/server.conf
+++ b/etc/conf/server.conf
@@ -54,9 +54,14 @@ ssl_ca_certs=etc/ssl/trust.cer
 # ============================================================
 
 # Whether to require client certificates when others connect to this server.
-# false = single-direction TLS (anyone can connect, auth at app layer).
 # true  = mutual TLS (clients must present a certificate signed by ssl_ca_certs).
-verify_client=false
+# false = single-direction TLS -- the external API (/api/v1/*) is NOT
+#         guarded at the application layer (auth_middleware only protects
+#         the internal API, /rest/v1/orchestrate/*), so anyone who can
+#         reach this port can call it. Only set false if something else
+#         (a reverse proxy, firewall, or network policy) is providing that
+#         protection instead.
+verify_client=true
 
 # Whether to verify remote server certificates when this service connects
 # outward (e.g., to the registry center or A2A agents).

--- a/tests/test_server_conf_defaults.py
+++ b/tests/test_server_conf_defaults.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Regression coverage for #10: etc/conf/server.conf shipped verify_client=false,
+silently overriding ConfObj's own secure default (ssl.CERT_REQUIRED, see
+TestConfObj.test_as_object_verify_client_default in test_cert_validator.py).
+With enable_https=true and no other reasoning to override it, the external
+API (/api/v1/*) ended up with no authentication at all -- auth_middleware
+only guards the internal API by design, and mTLS was the only thing meant
+to cover the external one.
+
+This test reads the actual shipped file, not a fixture, so it fails the
+moment that regression is reintroduced -- by anyone, including a future
+docs/config edit that doesn't touch this test file at all.
+"""
+
+import os
+
+import ssl
+
+from common.util.conf_obj import ConfObj
+
+_SERVER_CONF_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "etc", "conf", "server.conf"
+)
+
+
+def _parse_conf_file(path):
+    result = {}
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            result[key.strip()] = value.strip()
+    return result
+
+
+class TestShippedServerConfDefaults:
+    def test_verify_client_is_not_shipped_as_false(self):
+        conf = _parse_conf_file(_SERVER_CONF_PATH)
+        assert conf.get("verify_client", "").lower() != "false", (
+            "etc/conf/server.conf ships verify_client=false, which overrides "
+            "ConfObj's secure ssl.CERT_REQUIRED default and leaves the "
+            "external API (/api/v1/*) with no authentication at all when "
+            "enable_https=true (see #10)."
+        )
+
+    def test_shipped_config_resolves_to_cert_required(self):
+        conf = _parse_conf_file(_SERVER_CONF_PATH)
+        obj = ConfObj.as_object(conf)
+        assert obj.verify_client == ssl.CERT_REQUIRED


### PR DESCRIPTION
## Description

`etc/conf/server.conf`'s shipped sample default for `verify_client` was `false`, silently overriding `ConfObj`'s own secure default (`ssl.CERT_REQUIRED` — see `common/util/conf_obj.py`'s `DEFAULT_VERIFY_CLIENT` and the existing `test_as_object_verify_client_default` test in `tests/test_cert_validator.py`, which already asserts the *code's* default is secure).

`auth_middleware` only applies application-layer token auth to the internal API (`/rest/v1/orchestrate/*`) — it explicitly passes through everything else, including the external API (`/api/v1/*`), on the assumption that mTLS at the TLS layer covers it when `enable_https=true` and `verify_client=true`. With the shipped `false` default, an operator who enabled HTTPS but didn't think to also override `verify_client` (reasonably assuming HTTPS alone gave them real protection) got **zero authentication on the external API** instead: no mTLS (disabled) and no application-layer check (`auth_middleware` skips that path by design).

## What changed

- `etc/conf/server.conf`: `verify_client=false` → `true`, and rewrote the comment above it — the old one ("`false` = ... auth at app layer") was actively wrong about what covers the external API and likely contributed to the regression in the first place.
- `README.md` / `README_zh.md`: the step-by-step HTTPS setup example now shows `verify_client=true`; added an explicit warning to the "External API Protection" section that the shipped `enable_https=false` default leaves that API completely unauthenticated, and that `verify_client` should stay at its secure default once HTTPS is turned on.
- `tests/test_server_conf_defaults.py` (new): reads the actual shipped `etc/conf/server.conf` file (not a fixture) and asserts it doesn't ship `verify_client=false`, and that parsing it through `ConfObj` resolves to `ssl.CERT_REQUIRED`. Verified this catches the regression: reintroduced the old value locally and confirmed both new tests fail before re-applying the fix.

## Why this doesn't change behavior for the default (HTTP) deployment

`verify_client`'s resolved value is only ever read inside `CustomUvicornServer.run()`, which doesn't run when `enable_https=false` (the shipped default) — that code path uses plain `uvicorn.run()` instead. So this fix is inert for a default HTTP deployment, which already has zero protection on the external API by design (the strengthened doc warning now says so explicitly). What it fixes is the case where an operator deliberately turns HTTPS on.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

Validated locally: `pytest tests/ --ignore=tests/test_external_apis.py` — 440 passed, 7 pre-existing skips, 0 failures. 2 new tests in `tests/test_server_conf_defaults.py`.

One of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37 — independent of every other PR in that set (not part of the original #7→#16 sequence; applies cleanly against `main` on its own).
