### PR TITLE
fix: stop tracking db_config.json, ship a placeholder template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ etc/conf/task_prompt_stubs.json
 etc/ssl/
 etc/conf/agent_credentials.json
 etc/conf/server.conf
+etc/conf/db_config.json
 *.token.md
 *token*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ data/workflow_storage/ # File-based persistence (PSOP, PreFlow, execution record
 **Local-only files (do NOT commit):**
 - `workflow-designer/src/service/api.js` — Contains local debug configuration (API endpoint). Keep local modifications for development, do not include in commits.
 - `etc/conf/server.conf` — Local server configuration. Revert any local changes before committing.
+- `etc/conf/db_config.json` — Local PostgreSQL connection settings, including credentials. Gitignored; copy `etc/conf/db_config.json.template` to get started, and never commit the real file.
 
 ## Key commands reference
 

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ The external API (`/api/v1/*`) is protected by mTLS at the TLS layer when `enabl
 |-------------|---------|
 | `etc/conf/server.conf` | Server IP, port, TLS certificates, persistence mode, registry URL, access password |
 | `etc/conf/server.properties` | TLS versions, ciphers, rate limiting, connection limits, client_verify_server |
-| `etc/conf/db_config.json` | PostgreSQL connection settings |
+| `etc/conf/db_config.json` | PostgreSQL connection settings — gitignored; copy `etc/conf/db_config.json.template` to get started (only needed for `persistence_mode=postgresql`) |
 | `common/config/llm_config.json` | LLM/embed/rerank model endpoints (overridable via `LLM_*`, see below) |
 | `.env` | Your local overrides — gitignored. Also where the negotiation SDK reads its `A2AT_*` variables directly (see below) |
 | `common/config/README_en.md` | LLM configuration guide |

--- a/README_zh.md
+++ b/README_zh.md
@@ -368,7 +368,7 @@ python generate_selfsign_cert.py etc/ssl serverAuth
 |----------|------|
 | `etc/conf/server.conf` | 服务 IP、端口、TLS 证书、持久化模式、注册中心 URL, access password |
 | `etc/conf/server.properties` | TLS 版本、密码套件、流控参数、连接限制, client_verify_server |
-| `etc/conf/db_config.json` | PostgreSQL 连接配置 |
+| `etc/conf/db_config.json` | PostgreSQL 连接配置——已加入 .gitignore；复制 `etc/conf/db_config.json.template` 作为起点（仅 `persistence_mode=postgresql` 时需要） |
 | `common/config/llm_config.json` | LLM/Embedding/Rerank 模型端点（可通过 `LLM_*` 覆盖，见下文） |
 | `.env` | 本地覆盖配置 — 已加入 gitignore。协商 SDK 也直接从这里读取 `A2AT_*` 变量（见下文） |
 | `common/config/README_zh.md` | LLM 配置指南 |

--- a/etc/conf/db_config.json.template
+++ b/etc/conf/db_config.json.template
@@ -2,6 +2,6 @@
   "host": "127.0.0.1",
   "port": "5432",
   "database": "orchestration_center",
-  "user": "opena2a_t",
-  "password": "openA2A_T"
+  "user": "<YOUR_DB_USERNAME>",
+  "password": "<YOUR_DB_PASSWORD>"
 }

--- a/tests/test_db_config_template.py
+++ b/tests/test_db_config_template.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Regression coverage for #24: etc/conf/db_config.json was committed with a
+live-looking PostgreSQL user/password and was not gitignored, so every local
+edit kept flowing into history. It's now gitignored, untracked, and replaced
+in git by a placeholder etc/conf/db_config.json.template that
+database/utils/db_connection.py's read_db_config()/_ConnInfoHolder consumers
+expect a real db_config.json to structurally match.
+"""
+
+import json
+import os
+import subprocess
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_TEMPLATE_PATH = os.path.join(_REPO_ROOT, "etc", "conf", "db_config.json.template")
+
+
+class TestDbConfigTemplate:
+    def test_template_exists_and_is_valid_json(self):
+        with open(_TEMPLATE_PATH, "r", encoding="utf-8") as f:
+            config = json.load(f)
+        assert isinstance(config, dict)
+
+    def test_template_has_the_keys_db_connection_expects(self):
+        with open(_TEMPLATE_PATH, "r", encoding="utf-8") as f:
+            config = json.load(f)
+        assert set(config.keys()) == {"host", "port", "database", "user", "password"}
+
+    def test_template_does_not_ship_a_real_looking_credential(self):
+        with open(_TEMPLATE_PATH, "r", encoding="utf-8") as f:
+            config = json.load(f)
+        assert config["user"].startswith("<") and config["user"].endswith(">")
+        assert config["password"].startswith("<") and config["password"].endswith(">")
+
+
+class TestDbConfigJsonIsNotTracked:
+    def test_db_config_json_is_gitignored(self):
+        gitignore_path = os.path.join(_REPO_ROOT, ".gitignore")
+        with open(gitignore_path, "r", encoding="utf-8") as f:
+            lines = {line.strip() for line in f}
+        assert "etc/conf/db_config.json" in lines
+
+    def test_db_config_json_is_not_tracked_by_git(self):
+        result = subprocess.run(
+            ["git", "ls-files", "etc/conf/db_config.json"],
+            cwd=_REPO_ROOT, capture_output=True, text=True, check=True,
+        )
+        assert result.stdout.strip() == "", (
+            "etc/conf/db_config.json is still tracked by git -- it should "
+            "have been removed with `git rm --cached` (see #24)."
+        )


### PR DESCRIPTION
## Description

`etc/conf/db_config.json` was committed with a live-looking PostgreSQL `user`/`password` pair for the dev connection, and unlike `server.conf` and `agent_credentials.json` it was never added to `.gitignore` — every future local edit would keep flowing into history. (`agent_credentials.json` itself is no longer tracked at all as of this base — only its `.template` — so this PR only needs to handle `db_config.json`.)

## What changed

- Added `etc/conf/db_config.json` to `.gitignore`.
- `git rm --cached` it, following the pattern already established for `server.conf`: the file stays on disk for anyone who already has it configured locally, it just stops being trackable going forward.
- Added `etc/conf/db_config.json.template` with placeholder `user`/`password` values, mirroring the existing `etc/conf/agent_credentials.json.template`. `database/utils/db_connection.py`'s `read_db_config()` has no fallback to the template — it's a plain `open()` — so a fresh clone running `persistence_mode=postgresql` needs an explicit copy step; documented that in `README.md`/`README_zh.md`'s config table and in `AGENTS.md`'s "local-only files, do NOT commit" list (the upstream-tracked equivalent of the fork-local `CLAUDE.md`'s list the issue originally named — `CLAUDE.md` itself isn't part of this repo).
- `tests/test_db_config_template.py` (new): the template is valid JSON with exactly the keys `read_db_config()` expects and placeholder (not real-looking) values; `db_config.json` is both gitignored and no longer tracked by git.

## Deliberately out of scope

**Rotating the committed dev credential.** It's already exposed in git history regardless of this PR — history rewriting (`git filter-repo`/BFG) is a separate, disruptive decision this issue explicitly excludes from its own scope. Rotating a live database credential also isn't something to do silently inside a docs/gitignore PR: whoever owns that dev database should rotate it and confirm nothing still depends on the old value. Flagging it here so it doesn't get lost.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [ ] New source files include the SPDX license header — `db_config.json.template` is JSON, which can't carry comments/headers, matching the existing `agent_credentials.json.template`'s convention; the new test file does carry the header

## Additional Context

Validated locally: `pytest tests/ --ignore=tests/test_external_apis.py` — 443 passed, 7 pre-existing skips, 0 failures. 5 new tests in `tests/test_db_config_template.py`. `npm run lint` unaffected (0 errors, 31 warnings, no frontend files touched).

One of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37 — independent of every other PR in that set; applies cleanly against `main` on its own.
