### PR TITLE
fix: redact tokens/credentials from request logging

### DIFF
--- a/orchestrate/server/frontend_support_server.py
+++ b/orchestrate/server/frontend_support_server.py
@@ -125,11 +125,27 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         content=error(422, "; ".join(messages)),
     )
 
+# Query param keys that commonly carry credentials. access_token in
+# particular is how the session token reaches the backend for SSE
+# execution requests -- EventSource can't set an Authorization header, so
+# api.js puts it in the URL instead (see orchestrate/server/auth.py's
+# _extract_token). Logging it verbatim would write a live, still-valid
+# bearer token into the application log on every workflow execution.
+_SENSITIVE_QUERY_PARAM_KEYS = frozenset({"token", "access_token", "password", "api_key", "secret"})
+
+
+def _redact_sensitive_params(params: dict) -> dict:
+    return {
+        key: ("***" if key.lower() in _SENSITIVE_QUERY_PARAM_KEYS else value)
+        for key, value in params.items()
+    }
+
+
 @app.middleware("http")
 async def logging_middleware(request: Request, call_next):
     request_id = str(uuid.uuid4())[:8]
     client_ip = request.client.host if request.client else "unknown"
-    query_params = dict(request.query_params)
+    query_params = _redact_sensitive_params(dict(request.query_params))
     logger.info(f"[{request_id}] --> {request.method} {request.url.path} "
                 f"client={client_ip}"
                 f"{' params=' + str(query_params) if query_params else ''}")

--- a/tests/test_logging_middleware_redaction.py
+++ b/tests/test_logging_middleware_redaction.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Regression coverage for #39: every request logged its raw query params,
+including access_token -- the SSE execution stream puts the session token
+there because EventSource can't set an Authorization header. That wrote a
+live, still-valid bearer token into the application log on every workflow
+execution.
+"""
+
+import os
+
+os.environ.setdefault("TESTING", "True")
+
+from orchestrate.server.frontend_support_server import _redact_sensitive_params
+
+
+class TestRedactSensitiveParams:
+    def test_redacts_access_token(self):
+        result = _redact_sensitive_params({"access_token": "live-session-token-abc123"})
+        assert result == {"access_token": "***"}
+
+    def test_redacts_token(self):
+        result = _redact_sensitive_params({"token": "live-session-token-abc123"})
+        assert result == {"token": "***"}
+
+    def test_redacts_password_and_api_key_and_secret(self):
+        result = _redact_sensitive_params({
+            "password": "hunter2", "api_key": "sk-abc", "secret": "shh",
+        })
+        assert result == {"password": "***", "api_key": "***", "secret": "***"}
+
+    def test_redaction_is_case_insensitive(self):
+        result = _redact_sensitive_params({"Access_Token": "live-token", "TOKEN": "live-token"})
+        assert result == {"Access_Token": "***", "TOKEN": "***"}
+
+    def test_leaves_non_sensitive_params_untouched(self):
+        result = _redact_sensitive_params({"psop_id": "abc-123", "lang": "en"})
+        assert result == {"psop_id": "abc-123", "lang": "en"}
+
+    def test_mixed_params_only_redacts_sensitive_keys(self):
+        result = _redact_sensitive_params({"psop_id": "abc-123", "access_token": "live-token"})
+        assert result == {"psop_id": "abc-123", "access_token": "***"}
+
+    def test_empty_params(self):
+        assert _redact_sensitive_params({}) == {}


### PR DESCRIPTION
## Description

`logging_middleware` logged `dict(request.query_params)` verbatim for every request. The SSE execution stream puts the session token in the URL as `?access_token=...` because `EventSource` can't set an `Authorization` header (see `orchestrate/server/auth.py`'s `_extract_token`) — so every workflow execution wrote a live, still-valid bearer token (up to its ~12-hour TTL) into the application log, and into any upstream reverse-proxy access log that logs the request URL (e.g. the nginx container from hw-irc-sni/orchestration-center#36 / project-openan/orchestration-center#54).

This is a strictly worse variant of hw-irc-sni/orchestration-center#12's "default admin password logged in cleartext at startup" — a one-time credential printed once, versus a live session credential printed on every SSE-driven execution.

## What changed

Added `_redact_sensitive_params()` in `orchestrate/server/frontend_support_server.py`, replacing the value for `token`/`access_token`/`password`/`api_key`/`secret` keys (case-insensitive) with `"***"` before logging — matching the masking convention already used for LLM API keys in `common/llm/config/env_overrides.py`. Only the logged representation changes; the real query params passed to request handlers are untouched.

## Deliberately out of scope

The deeper fix — moving the SSE token off the URL entirely (e.g. a short-lived, single-use SSE ticket exchanged for the real session token) so it can't leak into *any* URL-logging layer, not just this one — is a larger change to the token-transport model. It's coordinated with hw-irc-sni/orchestration-center#9's httpOnly-cookie migration (9b, not yet started) since both touch the same credential-transport surface; not duplicating that scope here.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

Validated locally: `pytest tests/ --ignore=tests/test_external_apis.py` — 445 passed, 7 pre-existing skips, 0 failures. 7 new tests in `tests/test_logging_middleware_redaction.py`.

One of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37 — a finding surfaced during that umbrella's review with no prior issue (hw-irc-sni/orchestration-center#39). Independent of every other PR in the set; applies cleanly against `main` on its own.
