### PR TITLE
perf: cache has_any_user() and the database-existence check

### DIFF
--- a/database/utils/db_connection.py
+++ b/database/utils/db_connection.py
@@ -17,6 +17,7 @@
 
 import json
 import re
+import threading
 from pathlib import Path
 
 import psycopg2
@@ -50,36 +51,52 @@ class _ConnInfoHolder:
             validate_database_name(cls._instance.get('database', "orchestration_center"))
         return cls._instance
 
+# create_connection() is called on every /rest/v1/orchestrate/* request
+# (via is_auth_enabled() -> has_any_user()), so create_database_if_not_exists()
+# would otherwise open a second, throwaway connection to the `postgres`
+# maintenance database on every single request. The database's existence
+# only needs confirming once per process -- it doesn't spontaneously
+# disappear -- so cache a successful check (see #40).
+_database_verified = False
+_database_verified_lock = threading.Lock()
+
 def create_database_if_not_exists():
-    conn_info = _ConnInfoHolder.get()
-    default_conn_info = {**conn_info,  "database": "postgres"}
-    try:
-        conn = psycopg2.connect(**default_conn_info)
-        conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-        cursor = conn.cursor()
+    global _database_verified
+    if _database_verified:
+        return True
+    with _database_verified_lock:
+        if _database_verified:
+            return True
+        conn_info = _ConnInfoHolder.get()
+        default_conn_info = {**conn_info,  "database": "postgres"}
+        try:
+            conn = psycopg2.connect(**default_conn_info)
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            cursor = conn.cursor()
 
-        database_name = conn_info.get('database', "orchestration_center")
-        cursor.execute(
-            sql.SQL("SELECT 1 FROM pg_database WHERE datname = {}").format(
-                sql.Literal(database_name)
-            )
-        )
-        exists = cursor.fetchone()
-
-        if not exists:
+            database_name = conn_info.get('database', "orchestration_center")
             cursor.execute(
-                sql.SQL("CREATE DATABASE {}").format(
-                    sql.Identifier(database_name)
+                sql.SQL("SELECT 1 FROM pg_database WHERE datname = {}").format(
+                    sql.Literal(database_name)
                 )
             )
-            logger.info(f"Database {database_name} created successfully")
+            exists = cursor.fetchone()
 
-        cursor.close()
-        conn.close()
-        return True
-    except Exception as e:
-        logger.error(f"Failed to create database: {e}")
-        return False
+            if not exists:
+                cursor.execute(
+                    sql.SQL("CREATE DATABASE {}").format(
+                        sql.Identifier(database_name)
+                    )
+                )
+                logger.info(f"Database {database_name} created successfully")
+
+            cursor.close()
+            conn.close()
+            _database_verified = True
+            return True
+        except Exception as e:
+            logger.error(f"Failed to create database: {e}")
+            return False
 
 def create_connection():
     try:

--- a/database/utils/user_store.py
+++ b/database/utils/user_store.py
@@ -30,12 +30,31 @@ reset.
 
 import hashlib
 import secrets as _secrets
+import threading
 from typing import Optional
 
 from loguru import logger
 
 from database.utils.db_connection import create_connection
 from database.utils.query_execution import execute_query
+
+# has_any_user() gates is_auth_enabled() (orchestrate/server/auth.py),
+# which runs on every /rest/v1/orchestrate/* request -- an unpooled DB
+# round trip there is a self-inflicted amplification an unauthenticated
+# request flood can exploit (see #40). Once any user exists it can never
+# stop existing (delete_user() refuses to delete "admin"), so a True
+# result is cached for the process lifetime; only the "not yet seeded"
+# window before the first user still queries the database.
+_any_user_exists_cache = False
+_any_user_exists_lock = threading.Lock()
+
+
+def _mark_user_exists() -> None:
+    global _any_user_exists_cache
+    if not _any_user_exists_cache:
+        with _any_user_exists_lock:
+            _any_user_exists_cache = True
+
 
 # Current on-disk password scheme: password_hash = _hash_password(plaintext, salt).
 # 'legacy' rows instead hold _hash_password(sha256(plaintext), salt) -- the
@@ -72,6 +91,7 @@ def create_user(username: str, password: str, role: str = "user", must_change_pa
             logger.warning(f"Failed to create user '{username}': {err}")
             return False
         logger.info(f"User '{username}' created with role '{role}'")
+        _mark_user_exists()
         return True
     finally:
         conn.close()
@@ -202,13 +222,23 @@ def delete_user(username: str) -> bool:
 
 
 def has_any_user() -> bool:
-    """Check if any user exists in the database."""
+    """Check if any user exists in the database.
+
+    Cached once True (see the module-level note above) -- callers on a
+    hot path (is_auth_enabled()) skip the DB round trip entirely once at
+    least one user has ever been observed to exist.
+    """
+    if _any_user_exists_cache:
+        return True
     conn = create_connection()
     if conn is None:
         return False
     try:
         result, err = execute_query(conn, "SELECT 1 FROM users LIMIT 1", None)
-        return bool(result and not err)
+        found = bool(result and not err)
+        if found:
+            _mark_user_exists()
+        return found
     finally:
         conn.close()
 

--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Regression coverage for #40: create_database_if_not_exists() opened a
+throwaway connection to the `postgres` maintenance database on every call --
+and it was called on every /rest/v1/orchestrate/* request via
+create_connection() -> has_any_user() -> is_auth_enabled(). It's now cached
+for the process lifetime after a successful check.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from database.utils import db_connection
+
+
+@pytest.fixture(autouse=True)
+def _reset_database_verified_cache():
+    db_connection._database_verified = False
+    yield
+    db_connection._database_verified = False
+
+
+def _mock_pg_connection(existing_db=True):
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value = cursor
+    cursor.fetchone.return_value = (1,) if existing_db else None
+    return conn
+
+
+class TestCreateDatabaseIfNotExistsCaching:
+    def test_first_call_connects_and_caches_on_success(self):
+        with patch.object(db_connection, "_ConnInfoHolder") as mock_holder, \
+             patch.object(db_connection.psycopg2, "connect", return_value=_mock_pg_connection()) as mock_connect:
+            mock_holder.get.return_value = {"host": "127.0.0.1", "database": "orchestration_center"}
+            assert db_connection.create_database_if_not_exists() is True
+            assert mock_connect.call_count == 1
+            assert db_connection._database_verified is True
+
+    def test_second_call_does_not_reconnect(self):
+        with patch.object(db_connection, "_ConnInfoHolder") as mock_holder, \
+             patch.object(db_connection.psycopg2, "connect", return_value=_mock_pg_connection()) as mock_connect:
+            mock_holder.get.return_value = {"host": "127.0.0.1", "database": "orchestration_center"}
+            assert db_connection.create_database_if_not_exists() is True
+            assert db_connection.create_database_if_not_exists() is True
+            assert mock_connect.call_count == 1
+
+    def test_failed_attempt_is_not_cached_and_retries(self):
+        with patch.object(db_connection, "_ConnInfoHolder") as mock_holder, \
+             patch.object(db_connection.psycopg2, "connect", side_effect=Exception("connection refused")) as mock_connect:
+            mock_holder.get.return_value = {"host": "127.0.0.1", "database": "orchestration_center"}
+            assert db_connection.create_database_if_not_exists() is False
+            assert db_connection._database_verified is False
+            assert db_connection.create_database_if_not_exists() is False
+            assert mock_connect.call_count == 2
+
+    def test_creates_database_when_missing(self):
+        conn = _mock_pg_connection(existing_db=False)
+        with patch.object(db_connection, "_ConnInfoHolder") as mock_holder, \
+             patch.object(db_connection.psycopg2, "connect", return_value=conn):
+            mock_holder.get.return_value = {"host": "127.0.0.1", "database": "orchestration_center"}
+            assert db_connection.create_database_if_not_exists() is True
+            # SELECT (existence check) + CREATE DATABASE, since fetchone()
+            # was mocked to report the database missing.
+            assert conn.cursor().execute.call_count == 2
+
+
+class TestCreateConnectionUsesCachedCheck:
+    def test_create_connection_skips_recheck_once_cached(self):
+        db_connection._database_verified = True
+        with patch.object(db_connection, "_ConnInfoHolder") as mock_holder, \
+             patch.object(db_connection.psycopg2, "connect", return_value=MagicMock()) as mock_connect:
+            mock_holder.get.return_value = {"host": "127.0.0.1", "database": "orchestration_center"}
+            conn = db_connection.create_connection()
+            assert conn is not None
+            # Only the application-DB connection, not a second one for the
+            # `postgres` maintenance database.
+            assert mock_connect.call_count == 1

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -18,7 +18,16 @@
 import hashlib
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from database.utils import user_store
+
+
+@pytest.fixture(autouse=True)
+def _reset_any_user_exists_cache():
+    user_store._any_user_exists_cache = False
+    yield
+    user_store._any_user_exists_cache = False
 
 
 def _mock_conn():
@@ -62,6 +71,18 @@ class TestCreateUser:
     def test_returns_false_when_no_connection(self):
         with patch.object(user_store, "create_connection", return_value=None):
             assert user_store.create_user("alice", "pw") is False
+
+    def test_successful_creation_marks_a_user_as_existing(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, None)):
+            user_store.create_user("alice", "pw")
+            assert user_store._any_user_exists_cache is True
+
+    def test_failed_creation_does_not_mark_a_user_as_existing(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()), \
+             patch.object(user_store, "execute_query", return_value=(None, RuntimeError("boom"))):
+            user_store.create_user("alice", "pw")
+            assert user_store._any_user_exists_cache is False
 
 
 class TestAuthenticateUserV2Scheme:
@@ -258,6 +279,20 @@ class TestHasAnyUser:
     def test_false_when_no_connection(self):
         with patch.object(user_store, "create_connection", return_value=None):
             assert user_store.has_any_user() is False
+
+    def test_true_result_is_cached_and_skips_the_db_on_next_call(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()) as mock_create_conn, \
+             patch.object(user_store, "execute_query", return_value=([(1,)], None)):
+            assert user_store.has_any_user() is True
+            assert user_store.has_any_user() is True
+            mock_create_conn.assert_called_once()
+
+    def test_false_result_is_not_cached_and_rechecks_the_db(self):
+        with patch.object(user_store, "create_connection", return_value=_mock_conn()) as mock_create_conn, \
+             patch.object(user_store, "execute_query", return_value=([], None)):
+            assert user_store.has_any_user() is False
+            assert user_store.has_any_user() is False
+            assert mock_create_conn.call_count == 2
 
 
 class TestSaltUniqueness:


### PR DESCRIPTION
## Description

`is_auth_enabled()` (`orchestrate/server/auth.py`) calls `has_any_user()` on every `/rest/v1/orchestrate/*` request when `persistence_mode=postgresql` — it's what gates whether auth is required at all, so it necessarily runs before authentication is established. Each call went through `create_connection()`, which unconditionally called `create_database_if_not_exists()` first: that opened, queried, and closed a completely separate connection to the `postgres` maintenance database, every single time, before even connecting to the application database to run the actual `has_any_user()` query.

That's two new TCP connections plus two auth handshakes per incoming HTTP request, not per process lifetime — and each one logged a line. An unauthenticated request flood (trivially reachable, since this check runs before auth) could exhaust the Postgres connection limit and flood the application/database logs: one attacker request becoming two DB connections is a self-inflicted amplification.

## What changed

Neither check's result can become stale in the way that mattered here:

- The database doesn't spontaneously stop existing mid-process, so `create_database_if_not_exists()` (`database/utils/db_connection.py`) now caches a successful check (`_database_verified`) instead of re-verifying on every `create_connection()` call.
- Once any user exists, the `users` table can never become empty again — `delete_user()` refuses to delete `"admin"` — so `has_any_user()` (`database/utils/user_store.py`) now caches a `True` result (`_any_user_exists_cache`) for the process lifetime. `create_user()` also sets the cache directly on success, so the very next request after seeding/registering the first user skips the query too, not just the one after that.

Both caches are process-lifetime, not per-request or TTL-based — once true, the underlying fact this codebase can produce genuinely can't become false again. A failed `create_database_if_not_exists()` attempt is deliberately **not** cached, so a transient DB-unavailable startup still retries on the next call.

## Deliberately out of scope

The third option the issue suggests — connection pooling for `database/utils/db_connection.py` generally — is a larger architectural change touching every `create_connection()` caller across `user_store.py`, `table_creation.py`, and friends, all of which currently `close()` rather than release a pooled connection. The caching here removes the DB round trip from the actual hot path entirely once warm, which is the more surgical fix for what this issue describes; pooling the less-frequently-hit callers (login, workflow CRUD, ...) is a separate, larger change if it's ever needed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [ ] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

Validated locally: `pytest tests/ --ignore=tests/test_external_apis.py` — 447 passed, 7 pre-existing skips, 0 failures. 9 new tests: `tests/test_db_connection.py` (5, this module's first test coverage at all — caching, retry-on-failure, and the actual `CREATE DATABASE` path) plus 4 added to `tests/test_user_store.py` (cache hit/miss on `has_any_user()`, and `create_user()` setting the cache on success/not on failure).

One of several follow-up security-hardening items tracked in hw-irc-sni/orchestration-center#37 — a finding surfaced during that umbrella's review with no prior issue (hw-irc-sni/orchestration-center#40). Independent of every other PR in the set; applies cleanly against `main` on its own.
