### PR TITLE
fix: move session token from localStorage to an httpOnly cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,11 @@ This also brings up `workflow-designer`, the containerized frontend: a
 multi-stage build (`npm run build`, served by nginx) exposed at
 `http://localhost:3003`. nginx reverse-proxies `/api/orchestrate/` to the
 `orchestration-center` service on the compose network (matching the
-`defaultGateway` the frontend's `src/service/api.js` falls back to when
-served from a non-dev port), so the browser never needs a direct route to
-port 5001. Override the upstream with `BACKEND_HOST`/`BACKEND_PORT` env vars
-if you rename or repoint the backend service.
+`defaultGateway` the frontend's `src/service/api.js` defaults to), so the
+browser never needs a direct route to port 5001 -- keeping frontend and
+backend on the same origin, which the session cookie (see Authentication
+below) requires. Override the upstream with `BACKEND_HOST`/`BACKEND_PORT`
+env vars if you rename or repoint the backend service.
 
 **Development** — layers `docker-compose-dev.yml` on top, which switches
 `AGENT_REGISTRY_URL` to plain HTTP to match registry-center's dev stack
@@ -366,7 +367,9 @@ The internal API (`/rest/v1/orchestrate/*`) is protected by token-based authenti
 | `access_token_ttl` | Session token lifetime in seconds. | `43200` (12h) |
 | `persistence_mode` | `postgresql` enables database-backed user management; `file` uses config-based auth. | `file` |
 
-The frontend sends the password as-is; the backend is what hashes it (server-side, salted, for DB-mode accounts; against the configured SHA-256 in file mode). **This relies on `enable_https=true` for confidentiality in transit** -- see the TLS/HTTPS section below; don't run with the shipped `enable_https=false` default outside local development. Tokens are in-memory with TTL, passed via `Authorization: Bearer` header or `access_token` query parameter (for SSE/EventSource).
+The frontend sends the password as-is; the backend is what hashes it (server-side, salted, for DB-mode accounts; against the configured SHA-256 in file mode). **This relies on `enable_https=true` for confidentiality in transit** -- see the TLS/HTTPS section below; don't run with the shipped `enable_https=false` default outside local development. The session token is a `Secure` (when `enable_https=true`), `HttpOnly`, `SameSite=Lax` cookie set on login -- it's not readable from JavaScript (mitigates XSS token theft) and the browser attaches it automatically, including on `EventSource`/SSE connections, so it's never carried in a URL or logged as a query param. `Authorization: Bearer <token>` is also accepted as a fallback for non-browser clients (curl, scripts).
+
+A cookie only attaches to a **same-origin** request. Both shipped serving paths -- nginx in front of both in docker-compose, and the Vite dev server's own `/api/orchestrate` proxy for `npm run dev` -- put the frontend and this API on the same origin, so this is transparent. A manually-configured direct-IP deployment (frontend and backend on genuinely different origins) needs `CORS_ORIGINS` set to the frontend's exact origin (not the default `*`, which can't be combined with credentialed requests) for the cookie to work cross-origin at all.
 
 > **Session storage is single-process only.** Tokens live in an in-memory dict inside the running Python process. Running with multiple `uvicorn` workers, or multiple replicas behind a load balancer, will intermittently reject valid tokens -- a token minted by one worker isn't visible to another. Every process restart also logs out all active sessions (harmless in itself given the token TTL, but worth expecting). Both bundled launch paths (`orchestrate/start.py`) run single-process today, so this doesn't bite out of the box -- but if multi-worker or multi-replica deployment is ever needed, session storage must move to a shared backend (e.g. the same PostgreSQL database, or Redis) first.
 
@@ -431,9 +434,9 @@ The external API (`/api/v1/*`) is protected by mTLS at the TLS layer when `enabl
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/rest/v1/orchestrate/auth/login` | Login with username + password hash, returns session token |
+| `POST` | `/rest/v1/orchestrate/auth/login` | Login with username + password, sets the session cookie |
 | `POST` | `/rest/v1/orchestrate/auth/register` | Register a new user (PostgreSQL mode only) |
-| `POST` | `/rest/v1/orchestrate/auth/logout` | Revoke session token |
+| `POST` | `/rest/v1/orchestrate/auth/logout` | Revoke the session token and clear its cookie |
 | `GET` | `/rest/v1/orchestrate/auth/check` | Check if auth is required, token validity, and registration availability |
 | `GET` | `/rest/v1/orchestrate/auth/users` | List all users (PostgreSQL mode only) |
 | `DELETE` | `/rest/v1/orchestrate/auth/users/{username}` | Delete a user (admin cannot be deleted) |

--- a/README_zh.md
+++ b/README_zh.md
@@ -293,7 +293,9 @@ flowchart TB
 | `access_token_ttl` | 会话令牌有效期（秒）。 | `43200`（12小时） |
 | `persistence_mode` | `postgresql` 启用数据库用户管理；`file` 使用配置密码认证。 | `file` |
 
-前端按原样发送密码；由后端负责哈希（数据库模式下按用户加盐哈希；文件模式下与配置的 SHA-256 值比对）。**这依赖 `enable_https=true` 来保证传输过程的机密性**——见下方 TLS/HTTPS 一节；除本地开发外，不要使用默认的 `enable_https=false`。令牌存储在内存中，通过 `Authorization: Bearer` 请求头或 `access_token` 查询参数（用于 SSE/EventSource）传递。
+前端按原样发送密码；由后端负责哈希（数据库模式下按用户加盐哈希；文件模式下与配置的 SHA-256 值比对）。**这依赖 `enable_https=true` 来保证传输过程的机密性**——见下方 TLS/HTTPS 一节；除本地开发外，不要使用默认的 `enable_https=false`。会话令牌以 `Secure`（当 `enable_https=true` 时）、`HttpOnly`、`SameSite=Lax` 的 Cookie 形式在登录时下发——JavaScript 无法读取它（缓解 XSS 窃取令牌的风险），浏览器会自动携带它，包括在 `EventSource`/SSE 连接上，因此它不会出现在 URL 或作为查询参数被记录到日志中。为非浏览器客户端（curl、脚本）保留了 `Authorization: Bearer <token>` 作为后备方式。
+
+Cookie 只会在**同源**请求中被携带。当前提供的两种部署方式——docker-compose 中前后端都在 nginx 之后，以及 `npm run dev` 时 Vite 开发服务器自带的 `/api/orchestrate` 代理——都让前端与本 API 处于同一来源，因此这一点是透明的。若手动配置为直连 IP 部署（前后端确实处于不同源），则需要将 `CORS_ORIGINS` 设置为前端的确切来源（而非默认的 `*`，因为它无法与带凭证的请求组合使用），Cookie 才能跨源生效。
 
 > **会话存储仅限单进程。** 令牌保存在运行中 Python 进程的内存字典中。若以多个 `uvicorn` worker 运行，或在负载均衡后部署多个副本，会间歇性地拒绝本应有效的令牌——因为某个 worker 签发的令牌对其他 worker 不可见。每次进程重启也会导致所有活动会话登出（鉴于令牌本身有 TTL，这本身无害，但仍需提前预期）。当前内置的两条启动路径（`orchestrate/start.py`）都是单进程运行，因此默认情况下不会触发此问题——但如果之后需要多 worker 或多副本部署，必须先将会话存储迁移到共享后端（例如现有的 PostgreSQL 数据库，或 Redis）。
 
@@ -357,9 +359,9 @@ python generate_selfsign_cert.py etc/ssl serverAuth
 
 | 方法 | 端点 | 说明 |
 |------|------|------|
-| `POST` | `/rest/v1/orchestrate/auth/login` | 用户名 + 密码哈希登录，返回会话令牌 |
+| `POST` | `/rest/v1/orchestrate/auth/login` | 使用用户名 + 密码登录，设置会话 Cookie |
 | `POST` | `/rest/v1/orchestrate/auth/register` | 注册新用户（仅 PostgreSQL 模式） |
-| `POST` | `/rest/v1/orchestrate/auth/logout` | 撤销会话令牌 |
+| `POST` | `/rest/v1/orchestrate/auth/logout` | 撤销会话令牌并清除其 Cookie |
 | `GET` | `/rest/v1/orchestrate/auth/check` | 检查认证状态、令牌有效性及注册可用性 |
 | `GET` | `/rest/v1/orchestrate/auth/users` | 列出所有用户（仅 PostgreSQL 模式） |
 | `DELETE` | `/rest/v1/orchestrate/auth/users/{username}` | 删除用户（admin 不可删除） |

--- a/orchestrate/server/auth.py
+++ b/orchestrate/server/auth.py
@@ -34,7 +34,7 @@ import time
 from fastapi import HTTPException, Request
 from loguru import logger
 from starlette import status
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 
 from common.util.config_util import get_conf
 from orchestrate.server.response_utils import ok, error
@@ -48,6 +48,51 @@ _PUBLIC_AUTH_PATHS = {
 
 # Default token lifetime: 12 hours.
 _DEFAULT_TTL = 12 * 60 * 60
+
+# Session token is carried as an httpOnly cookie, scoped to the internal API
+# path so it's never sent to unrelated routes. Cookie name intentionally
+# differs from the old "?access_token=..." query param name it replaces
+# (see extract_token -- that scheme is no longer accepted at all), to make
+# the two easy to tell apart in logs/captures from before this migration.
+SESSION_COOKIE_NAME = "session_token"
+# Path=/ rather than the internal API prefix: the browser scopes cookies to
+# the URL it actually requested, which in gateway mode carries the
+# /api/orchestrate prefix the proxy (nginx or the Vite dev proxy) strips
+# before this backend ever sees the request. A narrower Path here matches
+# neither that prefixed shape nor the unprefixed one direct-IP mode uses,
+# so the browser would silently never send the cookie back at all -- login
+# would appear to succeed while every following request 401s. httpOnly
+# already blocks script-level reads, so the narrower scope bought nothing
+# a same-origin SPA+API deployment needed anyway.
+SESSION_COOKIE_PATH = "/"
+
+
+def _is_https_enabled() -> bool:
+    return str(get_conf().get("enable_https", True)).lower() == "true"
+
+
+def set_session_cookie(response: Response, token: str, ttl: int) -> None:
+    """Attach the session cookie to a response after a successful login.
+
+    ``secure`` tracks ``enable_https`` rather than being hardcoded True:
+    a Secure cookie is silently dropped by the browser over plain HTTP, and
+    enable_https=false is the shipped default (see #10) -- hardcoding this
+    would make login appear to succeed while never actually authenticating
+    any subsequent request.
+    """
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=token,
+        max_age=ttl,
+        path=SESSION_COOKIE_PATH,
+        httponly=True,
+        secure=_is_https_enabled(),
+        samesite="lax",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(key=SESSION_COOKIE_NAME, path=SESSION_COOKIE_PATH)
 
 
 def is_auth_enabled() -> bool:
@@ -169,12 +214,22 @@ def get_session_store() -> _SessionStore:
     return _session_store
 
 
-def _extract_token(request: Request) -> str | None:
-    """Extract the session token from the Authorization header or query param."""
+def extract_token(request: Request) -> str | None:
+    """Extract the session token from the session cookie, falling back to
+    the Authorization header for non-browser clients (curl, scripts).
+
+    No query-param fallback: that was the "?access_token=..." scheme this
+    migration replaces, which leaked the token into server access logs,
+    browser history, and Referer headers on every SSE call (see #39). The
+    frontend no longer sends it; EventSource picks up the cookie instead.
+    """
+    cookie_token = request.cookies.get(SESSION_COOKIE_NAME)
+    if cookie_token:
+        return cookie_token
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
         return auth_header[7:].strip()
-    return request.query_params.get("access_token")
+    return None
 
 
 def require_admin(request: Request) -> None:
@@ -186,7 +241,7 @@ def require_admin(request: Request) -> None:
     """
     if not is_auth_enabled():
         return
-    token = _extract_token(request)
+    token = extract_token(request)
     role = _session_store.get_role(token) if token else None
     if role != "admin":
         raise HTTPException(status_code=403, detail="Admin role required")
@@ -253,7 +308,7 @@ async def auth_middleware(request: Request, call_next):
     if path in _PUBLIC_AUTH_PATHS:
         return await call_next(request)
 
-    token = _extract_token(request)
+    token = extract_token(request)
     if not _session_store.validate(token):
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/orchestrate/server/frontend_support_server.py
+++ b/orchestrate/server/frontend_support_server.py
@@ -80,18 +80,27 @@ app = FastAPI(title="Workflow Orchestration API", version="1.0.0", docs_url=None
 config = get_conf()
 
 # CORS: restrict origins in production via CORS_ORIGINS env var (comma-separated).
-# allow_credentials=True is required for the session cookie to be sent on a
-# cross-origin request. The two shipped topologies (nginx in front of both
-# in docker-compose, the Vite dev proxy for `npm run dev`) put the frontend
-# and this API on the same origin from the browser's perspective, so CORS
-# never engages for them at all; CORS_ORIGINS only matters for a deployment
-# that deliberately talks to this API from a genuinely different origin.
+# Credentials (the session cookie) are only ever allowed alongside an
+# explicit, non-wildcard CORS_ORIGINS. Starlette's CORSMiddleware doesn't
+# reject allow_origins=["*"] + allow_credentials=True the way a browser
+# would reject a literal wildcard on the wire -- it silently echoes back
+# whatever Origin the request carries instead, which would let any origin
+# make a credentialed request to the internal API. This app also serves
+# /api/v1/* (external, mTLS-protected, meant to be reachable from a
+# third-party's own browser code), which is why the default stays
+# wildcard-permissive rather than locked down -- it just never gets
+# paired with allow_credentials unless an operator opts in by setting
+# CORS_ORIGINS to their real frontend origin (needed for the session
+# cookie to attach cross-origin at all; both shipped topologies, nginx in
+# docker-compose and the Vite dev proxy for `npm run dev`, are same-origin
+# and never hit this path regardless).
 _cors_origins_env = os.environ.get("CORS_ORIGINS", "*")
 _cors_origins = [o.strip() for o in _cors_origins_env.split(",") if o.strip()]
+_cors_allow_all_origins = "*" in _cors_origins
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
-    allow_credentials=True,
+    allow_credentials=not _cors_allow_all_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/orchestrate/server/frontend_support_server.py
+++ b/orchestrate/server/frontend_support_server.py
@@ -70,19 +70,28 @@ from orchestrate.server.auth import (
     mark_must_change_password,
     clear_must_change_password,
     username_must_change_password,
+    extract_token,
+    set_session_cookie,
+    clear_session_cookie,
 )
 
 app = FastAPI(title="Workflow Orchestration API", version="1.0.0", docs_url=None, redoc_url=None, openapi_url=None)
 
 config = get_conf()
 
-# CORS: restrict origins in production via CORS_ORIGINS env var (comma-separated)
+# CORS: restrict origins in production via CORS_ORIGINS env var (comma-separated).
+# allow_credentials=True is required for the session cookie to be sent on a
+# cross-origin request. The two shipped topologies (nginx in front of both
+# in docker-compose, the Vite dev proxy for `npm run dev`) put the frontend
+# and this API on the same origin from the browser's perspective, so CORS
+# never engages for them at all; CORS_ORIGINS only matters for a deployment
+# that deliberately talks to this API from a genuinely different origin.
 _cors_origins_env = os.environ.get("CORS_ORIGINS", "*")
 _cors_origins = [o.strip() for o in _cors_origins_env.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
-    allow_credentials=False,
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -125,12 +134,11 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         content=error(422, "; ".join(messages)),
     )
 
-# Query param keys that commonly carry credentials. access_token in
-# particular is how the session token reaches the backend for SSE
-# execution requests -- EventSource can't set an Authorization header, so
-# api.js puts it in the URL instead (see orchestrate/server/auth.py's
-# _extract_token). Logging it verbatim would write a live, still-valid
-# bearer token into the application log on every workflow execution.
+# Query param keys that commonly carry credentials. access_token no longer
+# reaches the backend this way -- the session token now travels as an
+# httpOnly cookie, which EventSource sends automatically without needing a
+# URL param -- but the key stays in this set as a defense-in-depth net for
+# any future/third-party caller that still passes a token via query string.
 _SENSITIVE_QUERY_PARAM_KEYS = frozenset({"token", "access_token", "password", "api_key", "secret"})
 
 
@@ -218,9 +226,9 @@ class RegisterRequest(BaseModel):
     password: str = Field(..., min_length=8, max_length=256, description="Password (plaintext, sent over TLS)")
 
 @router.post("/auth/login")
-async def login(request: LoginRequest, _: Any = Depends(LoginRateLimiter(config))):
+async def login(request: LoginRequest, response: Response, _: Any = Depends(LoginRateLimiter(config))):
     if not is_auth_enabled():
-        return ok(data={"auth_required": False, "token": None}, message="Authentication disabled")
+        return ok(data={"auth_required": False}, message="Authentication disabled")
     conf = get_conf()
     is_db_mode = conf.get("persistence_mode", "file").lower() == "postgresql"
     if is_db_mode:
@@ -234,9 +242,10 @@ async def login(request: LoginRequest, _: Any = Depends(LoginRateLimiter(config)
             else:
                 clear_must_change_password(user["username"])
             token, ttl = get_session_store().create(user["username"], role)
+            set_session_cookie(response, token, ttl)
             logger.info(f"Login successful (DB): {user['username']}")
             return ok(data={
-                "auth_required": True, "token": token, "expires_in": ttl,
+                "auth_required": True, "expires_in": ttl,
                 "username": user["username"], "role": role,
                 "must_change_password": must_change,
             })
@@ -249,8 +258,9 @@ async def login(request: LoginRequest, _: Any = Depends(LoginRateLimiter(config)
     computed = hashlib.sha256(request.password.encode()).hexdigest()
     if request.username == "admin" and stored and secrets.compare_digest(computed, stored):
         token, ttl = get_session_store().create("admin", "admin")
+        set_session_cookie(response, token, ttl)
         logger.info("Login successful (config): admin")
-        return ok(data={"auth_required": True, "token": token, "expires_in": ttl, "username": "admin", "role": "admin"})
+        return ok(data={"auth_required": True, "expires_in": ttl, "username": "admin", "role": "admin"})
     logger.warning(f"Login failed: username={request.username}")
     raise HTTPException(status_code=401, detail="Incorrect username or password")
 
@@ -274,11 +284,11 @@ async def register(request: RegisterRequest):
     raise HTTPException(status_code=500, detail="Failed to register user")
 
 @router.post("/auth/logout")
-async def logout(request: Request):
-    auth_header = request.headers.get("Authorization", "")
-    token = auth_header[7:].strip() if auth_header.startswith("Bearer ") else None
+async def logout(request: Request, response: Response):
+    token = extract_token(request)
     if token:
         get_session_store().revoke(token)
+    clear_session_cookie(response)
     return ok(message="Logged out")
 
 @router.get("/auth/check")
@@ -287,8 +297,7 @@ async def auth_check(request: Request):
     registration_enabled = conf.get("persistence_mode", "file").lower() == "postgresql"
     if not is_auth_enabled():
         return ok(data={"auth_required": False, "registration_enabled": registration_enabled})
-    auth_header = request.headers.get("Authorization", "")
-    token = auth_header[7:].strip() if auth_header.startswith("Bearer ") else None
+    token = extract_token(request)
     if token and get_session_store().validate(token):
         username = get_session_store().get_username(token)
         return ok(data={
@@ -355,8 +364,7 @@ async def change_password(request: ChangePasswordRequest, http_request: Request)
     """Change the current user's password. Requires a valid token."""
     conf = get_conf()
     is_db_mode = conf.get("persistence_mode", "file").lower() == "postgresql"
-    auth_header = http_request.headers.get("Authorization", "")
-    token = auth_header[7:].strip() if auth_header.startswith("Bearer ") else None
+    token = extract_token(http_request)
     username = get_session_store().get_username(token) if token else None
     if not username:
         raise HTTPException(status_code=401, detail="Not authenticated")

--- a/tests/test_auth_admin_gate.py
+++ b/tests/test_auth_admin_gate.py
@@ -24,20 +24,16 @@ from orchestrate.server import auth as auth_module
 from orchestrate.server.auth import _SessionStore, require_admin
 
 
-def _make_request(token: str | None = None, as_query_param: bool = False) -> Request:
+def _make_request(token: str | None = None) -> Request:
     headers = []
-    query_string = b""
     if token:
-        if as_query_param:
-            query_string = f"access_token={token}".encode()
-        else:
-            headers.append((b"authorization", f"Bearer {token}".encode()))
+        headers.append((b"authorization", f"Bearer {token}".encode()))
     scope = {
         "type": "http",
         "method": "GET",
         "path": "/rest/v1/orchestrate/auth/users",
         "headers": headers,
-        "query_string": query_string,
+        "query_string": b"",
     }
     return Request(scope)
 

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -31,12 +31,11 @@ from orchestrate.server import auth as auth_module
 from orchestrate.server.auth import _SessionStore, auth_middleware, _PUBLIC_AUTH_PATHS
 
 
-def _make_request(path, token=None, method="GET", as_query_param=False):
+def _make_request(path, token=None, method="GET", as_cookie=False):
     headers = []
-    query_string = b""
     if token:
-        if as_query_param:
-            query_string = f"access_token={token}".encode()
+        if as_cookie:
+            headers.append((b"cookie", f"session_token={token}".encode()))
         else:
             headers.append((b"authorization", f"Bearer {token}".encode()))
     scope = {
@@ -44,7 +43,7 @@ def _make_request(path, token=None, method="GET", as_query_param=False):
         "method": method,
         "path": path,
         "headers": headers,
-        "query_string": query_string,
+        "query_string": b"",
     }
     return Request(scope)
 
@@ -166,15 +165,32 @@ class TestAuthMiddleware:
         finally:
             store.revoke(token)
 
-    async def test_valid_token_via_query_param_passes_through(self, monkeypatch):
-        """SSE/EventSource can't set headers, so the token may arrive as
-        ?access_token=... instead of an Authorization header."""
+    async def test_valid_token_via_cookie_passes_through(self, monkeypatch):
+        """The session cookie is the primary path -- EventSource sends it
+        automatically without needing a header or URL param."""
         monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
         store = auth_module.get_session_store()
         token, _ = store.create("alice")
         try:
-            request = _make_request("/rest/v1/orchestrate/workflows", token=token, as_query_param=True)
+            request = _make_request("/rest/v1/orchestrate/workflows", token=token, as_cookie=True)
             response = await auth_middleware(request, _call_next)
             assert response.status_code == 200
+        finally:
+            store.revoke(token)
+
+    async def test_query_param_token_no_longer_accepted(self, monkeypatch):
+        """?access_token=... is the pre-migration scheme this replaces (see
+        #39) -- it must not be honored anymore."""
+        monkeypatch.setattr(auth_module, "is_auth_enabled", lambda: True)
+        store = auth_module.get_session_store()
+        token, _ = store.create("alice")
+        try:
+            scope = {
+                "type": "http", "method": "GET",
+                "path": "/rest/v1/orchestrate/workflows", "headers": [],
+                "query_string": f"access_token={token}".encode(),
+            }
+            response = await auth_middleware(Request(scope), _call_next)
+            assert response.status_code == 401
         finally:
             store.revoke(token)

--- a/tests/test_auth_server_side_hashing.py
+++ b/tests/test_auth_server_side_hashing.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import HTTPException, Request
 from pydantic import ValidationError
+from starlette.responses import Response
 
 os.environ.setdefault("TESTING", "True")
 
@@ -47,8 +48,10 @@ class TestLoginFileMode:
         monkeypatch.setattr(srv, "get_conf", lambda: {
             "persistence_mode": "file", "access_password": stored_hash,
         })
-        result = await srv.login(srv.LoginRequest(username="admin", password="MyRealPassword1!"))
-        assert result["data"]["token"] is not None
+        response = Response()
+        result = await srv.login(srv.LoginRequest(username="admin", password="MyRealPassword1!"), response)
+        assert result["data"]["auth_required"] is True
+        assert "session_token=" in response.headers["set-cookie"]
 
     async def test_wrong_plaintext_password_rejected(self, monkeypatch):
         monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
@@ -57,7 +60,7 @@ class TestLoginFileMode:
             "persistence_mode": "file", "access_password": stored_hash,
         })
         with pytest.raises(HTTPException) as exc_info:
-            await srv.login(srv.LoginRequest(username="admin", password="wrong-password"))
+            await srv.login(srv.LoginRequest(username="admin", password="wrong-password"), Response())
         assert exc_info.value.status_code == 401
 
     async def test_previously_client_hashed_value_no_longer_works(self, monkeypatch):
@@ -70,7 +73,7 @@ class TestLoginFileMode:
         })
         old_client_hash = hashlib.sha256(b"MyRealPassword1!").hexdigest()
         with pytest.raises(HTTPException) as exc_info:
-            await srv.login(srv.LoginRequest(username="admin", password=old_client_hash))
+            await srv.login(srv.LoginRequest(username="admin", password=old_client_hash), Response())
         assert exc_info.value.status_code == 401
 
 

--- a/tests/test_session_cookie.py
+++ b/tests/test_session_cookie.py
@@ -129,6 +129,24 @@ class TestLogoutClearsSessionCookie:
         assert auth_module.get_session_store().validate(token) is False
 
 
+class TestCorsCredentialsNeverPairWithWildcard:
+    """Regression coverage: Starlette's CORSMiddleware doesn't reject
+    allow_origins=["*"] + allow_credentials=True the way a browser rejects a
+    literal wildcard on the wire -- it silently echoes back whatever Origin
+    the request carries, which would let any origin make a credentialed
+    (cookie-carrying) request to the internal API. allow_credentials must
+    never be True while the origin allowlist is still the wildcard default.
+    """
+
+    def test_cors_middleware_does_not_pair_wildcard_origin_with_credentials(self):
+        cors = next(
+            m for m in srv.app.user_middleware
+            if m.cls.__name__ == "CORSMiddleware"
+        )
+        if "*" in cors.kwargs["allow_origins"]:
+            assert cors.kwargs["allow_credentials"] is False
+
+
 class TestExtractTokenPrecedence:
     def test_cookie_used_when_present(self):
         response = Response()

--- a/tests/test_session_cookie.py
+++ b/tests/test_session_cookie.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Regression coverage for 9b: the session token moved from a JSON body
+field (stored client-side in localStorage) to an httpOnly cookie.
+"""
+
+import hashlib
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.responses import Response
+
+from orchestrate.server import auth as auth_module
+from orchestrate.server import frontend_support_server as srv
+from orchestrate.server.auth import SESSION_COOKIE_NAME, SESSION_COOKIE_PATH
+
+BASE = "/rest/v1/orchestrate"
+
+
+def _file_mode_conf(password: str, enable_https: str = "false") -> dict:
+    stored_hash = hashlib.sha256(password.encode()).hexdigest()
+    return {"persistence_mode": "file", "access_password": stored_hash, "enable_https": enable_https}
+
+
+@pytest.fixture
+def client():
+    with TestClient(srv.app) as c:
+        yield c
+
+
+class TestLoginSetsSessionCookie:
+    def test_cookie_is_httponly_samesite_lax_scoped_to_internal_api(self, client, monkeypatch):
+        monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
+        conf = _file_mode_conf("MyRealPassword1!")
+        monkeypatch.setattr(srv, "get_conf", lambda: conf)
+        monkeypatch.setattr(auth_module, "get_conf", lambda: conf)
+
+        resp = client.post(f"{BASE}/auth/login", json={"username": "admin", "password": "MyRealPassword1!"})
+
+        assert resp.status_code == 200
+        assert resp.cookies.get(SESSION_COOKIE_NAME) is not None
+        set_cookie = resp.headers["set-cookie"]
+        assert "HttpOnly" in set_cookie
+        assert "samesite=lax" in set_cookie.lower()
+        # Exact-match, not a substring check: "Path=/" is also a substring of
+        # "Path=/rest/v1/orchestrate", which would let a regression to the
+        # narrower (browser-unreachable in gateway mode -- see
+        # SESSION_COOKIE_PATH's docstring) scope slip past this test.
+        attributes = {a.strip().split("=")[0].lower(): a.strip() for a in set_cookie.split(";")}
+        assert attributes["path"] == f"Path={SESSION_COOKIE_PATH}"
+
+    def test_secure_flag_follows_enable_https_true(self, client, monkeypatch):
+        monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
+        conf = _file_mode_conf("MyRealPassword1!", enable_https="true")
+        monkeypatch.setattr(srv, "get_conf", lambda: conf)
+        monkeypatch.setattr(auth_module, "get_conf", lambda: conf)
+
+        resp = client.post(f"{BASE}/auth/login", json={"username": "admin", "password": "MyRealPassword1!"})
+
+        assert "secure" in resp.headers["set-cookie"].lower()
+
+    def test_secure_flag_follows_enable_https_false(self, client, monkeypatch):
+        """enable_https=false is the shipped default (#10) -- a Secure
+        cookie would be silently dropped by the browser over plain HTTP,
+        breaking every subsequent authenticated request."""
+        monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
+        conf = _file_mode_conf("MyRealPassword1!", enable_https="false")
+        monkeypatch.setattr(srv, "get_conf", lambda: conf)
+        monkeypatch.setattr(auth_module, "get_conf", lambda: conf)
+
+        resp = client.post(f"{BASE}/auth/login", json={"username": "admin", "password": "MyRealPassword1!"})
+
+        assert "secure" not in resp.headers["set-cookie"].lower()
+
+    def test_response_body_no_longer_carries_the_token(self, client, monkeypatch):
+        """httpOnly is meaningless if the very login response still hands
+        the token back in a script-readable JSON body."""
+        monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
+        conf = _file_mode_conf("MyRealPassword1!")
+        monkeypatch.setattr(srv, "get_conf", lambda: conf)
+        monkeypatch.setattr(auth_module, "get_conf", lambda: conf)
+
+        resp = client.post(f"{BASE}/auth/login", json={"username": "admin", "password": "MyRealPassword1!"})
+
+        assert "token" not in resp.json()["data"]
+
+
+class TestLogoutClearsSessionCookie:
+    def test_logout_expires_the_cookie(self, client, monkeypatch):
+        monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
+        conf = _file_mode_conf("MyRealPassword1!")
+        monkeypatch.setattr(srv, "get_conf", lambda: conf)
+        monkeypatch.setattr(auth_module, "get_conf", lambda: conf)
+        client.post(f"{BASE}/auth/login", json={"username": "admin", "password": "MyRealPassword1!"})
+        assert client.cookies.get(SESSION_COOKIE_NAME) is not None
+
+        resp = client.post(f"{BASE}/auth/logout")
+
+        assert resp.status_code == 200
+        set_cookie = resp.headers["set-cookie"]
+        assert f"{SESSION_COOKIE_NAME}=" in set_cookie
+        assert ("Max-Age=0" in set_cookie) or ("01 Jan 1970" in set_cookie)
+
+    def test_logout_revokes_the_underlying_token(self, client, monkeypatch):
+        monkeypatch.setattr(srv, "is_auth_enabled", lambda: True)
+        conf = _file_mode_conf("MyRealPassword1!")
+        monkeypatch.setattr(srv, "get_conf", lambda: conf)
+        monkeypatch.setattr(auth_module, "get_conf", lambda: conf)
+        client.post(f"{BASE}/auth/login", json={"username": "admin", "password": "MyRealPassword1!"})
+        token = client.cookies.get(SESSION_COOKIE_NAME)
+
+        client.post(f"{BASE}/auth/logout")
+
+        assert auth_module.get_session_store().validate(token) is False
+
+
+class TestExtractTokenPrecedence:
+    def test_cookie_used_when_present(self):
+        response = Response()
+        request_scope = {
+            "type": "http", "method": "GET", "path": "/x",
+            "headers": [(b"cookie", b"session_token=cookie-token")],
+            "query_string": b"",
+        }
+        from fastapi import Request
+        assert auth_module.extract_token(Request(request_scope)) == "cookie-token"
+
+    def test_bearer_header_used_as_fallback_for_scripted_clients(self):
+        from fastapi import Request
+        request_scope = {
+            "type": "http", "method": "GET", "path": "/x",
+            "headers": [(b"authorization", b"Bearer header-token")],
+            "query_string": b"",
+        }
+        assert auth_module.extract_token(Request(request_scope)) == "header-token"
+
+    def test_query_param_no_longer_honored(self):
+        from fastapi import Request
+        request_scope = {
+            "type": "http", "method": "GET", "path": "/x",
+            "headers": [],
+            "query_string": b"access_token=leaked-token",
+        }
+        assert auth_module.extract_token(Request(request_scope)) is None

--- a/workflow-designer/src/App.jsx
+++ b/workflow-designer/src/App.jsx
@@ -19,7 +19,7 @@ import {useEffect, useState} from "react";
 import Header from "@/components/common/header/index.jsx";
 import Login from "@/components/common/login/index.jsx";
 import PasswordChangeModal from "@/components/common/password_change/index.jsx";
-import {authCheck, setAuthToken} from "@/service/api.js";
+import {authCheck, logout} from "@/service/api.js";
 import AgentRegistry from "./components/registry_center/index.jsx";
 import OrchestrationCenter from "@/components/orchestration_center/index.jsx";
 import ExecutionCenter from "@/components/execution_center/index.jsx";
@@ -64,11 +64,16 @@ const MainContainer = () => {
         return () => window.removeEventListener('auth-expired', handleAuthExpired);
     }, []);
 
-   const handleLogout = () => {
-       setAuthToken(null);
-       setAuthState('unauthenticated');
-       setCurrentUser(null);
-       setMustChangePassword(false);
+   const handleLogout = async () => {
+       // The session cookie is httpOnly -- only the server can clear it, so
+       // this has to hit /auth/logout rather than just resetting local state.
+       try {
+           await logout();
+       } finally {
+           setAuthState('unauthenticated');
+           setCurrentUser(null);
+           setMustChangePassword(false);
+       }
    };
 
    const [activeTab, setActiveTab] = useState(() => {

--- a/workflow-designer/src/components/common/login/index.jsx
+++ b/workflow-designer/src/components/common/login/index.jsx
@@ -30,7 +30,10 @@ const {t, i18n} = useTranslation();
         setError("");
         try {
            const data = await login(username, password);
-           if (data && data.token) {
+           if (data && data.auth_required) {
+                // The session token is an httpOnly cookie now -- it's never
+                // in this body, so a successful authenticated login is
+                // distinguished by auth_required being true, not a token.
                 onLoginWithUser ? onLoginWithUser(data.username, data.must_change_password) : onLoginSuccess();
            } else if (data && data.auth_required === false) {
                onLoginSuccess();
@@ -63,8 +66,10 @@ const {t, i18n} = useTranslation();
         try {
             await register(username, password);
             const data = await login(username, password);
-           if (data && data.token) {
+           if (data && data.auth_required) {
                 onLoginWithUser ? onLoginWithUser(data.username, data.must_change_password) : onLoginSuccess();
+            } else if (data && data.auth_required === false) {
+                onLoginSuccess();
             }
        } catch (err) {
             const msg = err?.response?.data?.message || err?.message || "";

--- a/workflow-designer/src/components/execution_center/index.jsx
+++ b/workflow-designer/src/components/execution_center/index.jsx
@@ -560,7 +560,7 @@ const ExecutionCenter = ({ isDark }) => {
         setEdges([]);
 
         const url = getDispatchStreamUrl(userIntent, selectedAgent, i18n.language);
-        const es = new EventSource(url);
+        const es = new EventSource(url, { withCredentials: true });
 
         es.onmessage = (event) => {
             try {
@@ -952,7 +952,7 @@ const ExecutionCenter = ({ isDark }) => {
         setSelectedExecutionId(null);
 
         const url = getStartProcessStreamUrl(idToRun, userIntent, i18n.language, selectedAgent);
-        const es = new EventSource(url);
+        const es = new EventSource(url, { withCredentials: true });
 
         es.onmessage = (event) => {
             try {

--- a/workflow-designer/src/service/api.js
+++ b/workflow-designer/src/service/api.js
@@ -20,37 +20,21 @@ const STORAGE_KEY = 'server_config';
 export const defaultIp = '127.0.0.1';
 export const defaultPort = '5001';
 export const defaultGateway = '/api/orchestrate';
- 
- const TOKEN_KEY = 'access_token';
- 
- export const getAuthToken = () => localStorage.getItem(TOKEN_KEY);
- export const setAuthToken = (token) => {
-     if (token) {
-         localStorage.setItem(TOKEN_KEY, token);
-     } else {
-         localStorage.removeItem(TOKEN_KEY);
-    }
-};
 
  // Protocol follows the current page: HTTPS page -> https://, otherwise http://
 export const defaultProtocol = window.location.protocol === 'https:' ? 'https://' : 'http://';
 
 const trimTrailingSlash = (url) => url.replace(/\/$/, '');
 
-const isStandardPort = () => {
-    const p = window.location.port;
-    return !p || p === '80' || p === '443';
-};
-
-const isLocalHost = () => ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname);
-
-// A remote client can never reach a backend at 127.0.0.1 (the browser's own
-// loopback), so direct-IP mode is only a safe unconfigured default when the
-// page itself was loaded from localhost (the local `npm run dev` workflow).
-// Anywhere else (including this project's own docker-compose deployment,
-// which serves the nginx-fronted UI on the non-standard port 3003) must
-// default to the nginx gateway path instead.
-export const shouldDefaultToGateway = () => isStandardPort() || !isLocalHost();
+// The session cookie (see login()/logout() below) is httpOnly and scoped to
+// the internal API path, so the browser only attaches it on a same-origin
+// request. Both shipped serving paths -- nginx in docker-compose, and the
+// Vite dev server's own /api/orchestrate proxy for `npm run dev` -- put the
+// frontend and this API on the same origin, so the gateway path is always
+// the correct default; direct-IP mode remains available as an explicit,
+// manually-configured choice (see the settings UI) for deployments that
+// don't run behind either proxy.
+export const shouldDefaultToGateway = () => true;
 
 export const getBaseUrl = () => {
     try {
@@ -75,22 +59,16 @@ export const getBaseUrl = () => {
 
 const ORCHESTRATE_BASE = () => `${getBaseUrl()}/rest/v1/orchestrate`;
 
-const api = axios.create({ timeout: 120000 });
+// withCredentials: true so the httpOnly session cookie is sent on every
+// request (and stored from every Set-Cookie response) -- same-origin via
+// the gateway path this makes no difference, but it's what a cross-origin
+// direct-IP deployment needs for the cookie to attach at all.
+const api = axios.create({ timeout: 120000, withCredentials: true });
 
- // Inject auth token into every request
- api.interceptors.request.use((config) => {
-     const token = getAuthToken();
-     if (token) {
-         config.headers.Authorization = `Bearer ${token}`;
-     }
-     return config;
- });
- 
 api.interceptors.response.use(
     (response) => response.data,
     (error) => {
         if (error.response && error.response.status === 401) {
-            setAuthToken(null);
             window.dispatchEvent(new Event('auth-expired'));
         }
         return Promise.reject(error);
@@ -205,10 +183,6 @@ export async function matchWorkflowsTopN(intent, topN = 3) {
 export function getStartProcessStreamUrl(psopId, userIntent = '', lang = '', targetAgent = '') {
     const base = `${ORCHESTRATE_BASE()}/execute?psop_id=${psopId}`;
     const params = [];
-    const token = getAuthToken();
-    if (token) {
-        params.push(`access_token=${encodeURIComponent(token)}`);
-    }
     if (userIntent) {
         params.push(`user_intent=${encodeURIComponent(userIntent)}`);
     }
@@ -227,10 +201,6 @@ export function getStartProcessStreamUrl(psopId, userIntent = '', lang = '', tar
 export function getDispatchStreamUrl(intent, agentName, lang = '') {
     const base = `${ORCHESTRATE_BASE()}/dispatch`;
     const params = [];
-    const token = getAuthToken();
-    if (token) {
-        params.push(`access_token=${encodeURIComponent(token)}`);
-    }
     params.push(`intent=${encodeURIComponent(intent)}`);
     params.push(`agent_name=${encodeURIComponent(agentName)}`);
     if (lang) {
@@ -261,19 +231,17 @@ export async function authCheck() {
 }
  
 export async function login(username, password) {
+    // The session token arrives as an httpOnly Set-Cookie header, not in
+    // this body -- the browser stores it and attaches it automatically,
+    // this code never sees or handles the token value at all.
     const body = await api.post(`${ORCHESTRATE_BASE()}/auth/login`, { username, password });
-    if (body.data && body.data.token) {
-         setAuthToken(body.data.token);
-     }
-     return body.data;
- }
- 
+    return body.data;
+}
+
 export async function logout() {
-    try {
-        await api.post(`${ORCHESTRATE_BASE()}/auth/logout`);
-    } finally {
-        setAuthToken(null);
-    }
+    // The server clears the cookie via Set-Cookie on this response; there's
+    // no client-side token state left to clean up on our end.
+    await api.post(`${ORCHESTRATE_BASE()}/auth/logout`);
 }
  
 export async function register(username, password) {

--- a/workflow-designer/src/service/api.test.js
+++ b/workflow-designer/src/service/api.test.js
@@ -37,8 +37,6 @@ import {
   getExecutionRecords,
   getExecutionRecord,
   deleteExecutionRecord,
-  getAuthToken,
-  setAuthToken,
   authCheck,
   login,
   logout,
@@ -95,9 +93,9 @@ describe('api service', () => {
   });
 
   describe('getBaseUrl', () => {
-    it('should return default URL when localStorage is empty', () => {
+    it('should return the gateway URL when localStorage is empty', () => {
       const url = getBaseUrl();
-      expect(url).toBe(`http://${defaultIp}:${defaultPort}`);
+      expect(url).toBe(defaultGateway);
     });
 
     it('should return custom URL when localStorage has config', () => {
@@ -140,6 +138,11 @@ describe('api service', () => {
     });
 
     describe('with no saved config, on a non-standard port', () => {
+      // Regression coverage for 9b: the session cookie only attaches on a
+      // same-origin request, so the gateway path (proxied by nginx in
+      // docker-compose, or by Vite's dev server for `npm run dev`) must be
+      // the default everywhere -- including localhost:3003, which used to
+      // default to a cross-origin direct-IP call that a cookie can't reach.
       const originalLocation = window.location;
 
       const setHostname = (hostname) => {
@@ -153,22 +156,22 @@ describe('api service', () => {
         Object.defineProperty(window, 'location', { value: originalLocation, configurable: true });
       });
 
-      it('falls back to the nginx gateway for a remote hostname (regression: was defaulting to 127.0.0.1, unreachable from a real client)', () => {
+      it('uses the gateway for a remote hostname (regression: was defaulting to 127.0.0.1, unreachable from a real client)', () => {
         setHostname('10.220.239.88');
         expect(shouldDefaultToGateway()).toBe(true);
         expect(getBaseUrl()).toBe(defaultGateway);
       });
 
-      it('still uses direct-IP mode when loaded from localhost (local `npm run dev` workflow)', () => {
+      it('uses the gateway when loaded from localhost (local `npm run dev` workflow, proxied by vite.config.js)', () => {
         setHostname('localhost');
-        expect(shouldDefaultToGateway()).toBe(false);
-        expect(getBaseUrl()).toBe(`http://${defaultIp}:${defaultPort}`);
+        expect(shouldDefaultToGateway()).toBe(true);
+        expect(getBaseUrl()).toBe(defaultGateway);
       });
 
-      it('still uses direct-IP mode when loaded from 127.0.0.1', () => {
+      it('uses the gateway when loaded from 127.0.0.1', () => {
         setHostname('127.0.0.1');
-        expect(shouldDefaultToGateway()).toBe(false);
-        expect(getBaseUrl()).toBe(`http://${defaultIp}:${defaultPort}`);
+        expect(shouldDefaultToGateway()).toBe(true);
+        expect(getBaseUrl()).toBe(defaultGateway);
       });
     });
   });
@@ -363,42 +366,19 @@ describe('api service', () => {
   });
 
   // Regression coverage for #16: this file previously had zero tests for
-  // login/register/changePassword or the two axios interceptors, despite
+  // login/register/changePassword or the response interceptor, despite
   // #9 (9a) changing exactly what these functions send over the wire.
+  // Regression coverage for 9b: the session token moved from a JSON body
+  // field (read into localStorage, replayed as an Authorization header) to
+  // an httpOnly cookie the browser handles entirely on its own -- api.js no
+  // longer touches the token value at all, so there's nothing left here to
+  // assert about token storage or a request interceptor (both removed).
   describe('Access authentication', () => {
-    // Interceptors are registered once, at module import time -- before any
-    // beforeEach in this suite runs and calls vi.clearAllMocks(). Capture
-    // the real callbacks here, during test collection, not inside an it().
+    // The response interceptor is registered once, at module import time --
+    // before any beforeEach in this suite runs and calls vi.clearAllMocks().
+    // Capture the real callback here, during test collection, not inside an it().
     const mockApi = axios.create();
-    const requestInterceptor = mockApi.interceptors.request.use.mock.calls[0][0];
     const [responseSuccessInterceptor, responseErrorInterceptor] = mockApi.interceptors.response.use.mock.calls[0];
-
-    describe('token storage', () => {
-      it('getAuthToken reads what setAuthToken wrote', () => {
-        setAuthToken('my-token');
-        expect(getAuthToken()).toBe('my-token');
-      });
-
-      it('setAuthToken(null) clears the stored token', () => {
-        setAuthToken('my-token');
-        setAuthToken(null);
-        expect(getAuthToken()).toBeNull();
-      });
-    });
-
-    describe('request interceptor', () => {
-      it('injects Authorization when a token is stored', () => {
-        setAuthToken('my-token');
-        const config = requestInterceptor({ headers: {} });
-        expect(config.headers.Authorization).toBe('Bearer my-token');
-      });
-
-      it('leaves Authorization unset when no token is stored', () => {
-        setAuthToken(null);
-        const config = requestInterceptor({ headers: {} });
-        expect(config.headers.Authorization).toBeUndefined();
-      });
-    });
 
     describe('response interceptor', () => {
       it('unwraps response.data on success', () => {
@@ -406,38 +386,37 @@ describe('api service', () => {
         expect(result).toEqual({ status: 'success' });
       });
 
-      it('clears the token and dispatches auth-expired on a 401', async () => {
-        setAuthToken('my-token');
+      it('dispatches auth-expired on a 401', async () => {
         const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
         const error = { response: { status: 401 } };
 
         await expect(responseErrorInterceptor(error)).rejects.toBe(error);
-        expect(getAuthToken()).toBeNull();
         expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'auth-expired' }));
         dispatchSpy.mockRestore();
       });
 
-      it('leaves the token alone on a non-401 error', async () => {
-        setAuthToken('my-token');
+      it('does not dispatch auth-expired on a non-401 error', async () => {
         const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
         const error = { response: { status: 500 } };
 
         await expect(responseErrorInterceptor(error)).rejects.toBe(error);
-        expect(getAuthToken()).toBe('my-token');
         expect(dispatchSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'auth-expired' }));
         dispatchSpy.mockRestore();
       });
 
-      it('leaves the token alone on a network error with no response', async () => {
+      it('does not dispatch auth-expired on a network error with no response', async () => {
+        const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
         const error = {};
+
         await expect(responseErrorInterceptor(error)).rejects.toBe(error);
-        // Must not throw on error.response being undefined.
+        expect(dispatchSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'auth-expired' }));
+        dispatchSpy.mockRestore();
       });
     });
 
     describe('login/register/changePassword send plaintext (regression for #9)', () => {
       it('login sends the password as-is, not a SHA-256 digest of it', async () => {
-        mockApi.post.mockResolvedValue({ data: { token: 'abc123', username: 'alice', role: 'user' } });
+        mockApi.post.mockResolvedValue({ data: { username: 'alice', role: 'user' } });
 
         await login('alice', 'MyRealPassword1!');
         expect(mockApi.post).toHaveBeenCalledWith(
@@ -446,19 +425,11 @@ describe('api service', () => {
         );
       });
 
-      it('login stores the returned token', async () => {
-        mockApi.post.mockResolvedValue({ data: { token: 'abc123', username: 'alice', role: 'user' } });
+      it('login returns the response data as-is (the session token is a cookie, never in this body)', async () => {
+        mockApi.post.mockResolvedValue({ data: { username: 'alice', role: 'user' } });
 
-        await login('alice', 'MyRealPassword1!');
-        expect(getAuthToken()).toBe('abc123');
-      });
-
-      it('login does not store a token when auth is disabled', async () => {
-        mockApi.post.mockResolvedValue({ data: { auth_required: false, token: null } });
-
-        setAuthToken(null);
-        await login('alice', 'anything');
-        expect(getAuthToken()).toBeNull();
+        const result = await login('alice', 'MyRealPassword1!');
+        expect(result).toEqual({ username: 'alice', role: 'user' });
       });
 
       it('register sends the password as-is, not a SHA-256 digest of it', async () => {
@@ -490,21 +461,17 @@ describe('api service', () => {
         expect(result).toEqual({ authenticated: false });
       });
 
-      it('logout posts to /auth/logout and clears the token', async () => {
-        setAuthToken('my-token');
+      it('logout posts to /auth/logout (the server clears the cookie via Set-Cookie)', async () => {
         mockApi.post.mockResolvedValue({ data: {} });
 
         await logout();
         expect(mockApi.post).toHaveBeenCalledWith(expect.stringContaining('/auth/logout'));
-        expect(getAuthToken()).toBeNull();
       });
 
-      it('logout clears the token even if the request fails', async () => {
-        setAuthToken('my-token');
+      it('logout propagates a request failure', async () => {
         mockApi.post.mockRejectedValue(new Error('network error'));
 
         await expect(logout()).rejects.toThrow('network error');
-        expect(getAuthToken()).toBeNull();
       });
 
       it('listUsers calls GET /auth/users', async () => {


### PR DESCRIPTION
## Description

`#9`'s review split the credential rewrite into two parts: 9a (server-side password hashing, merged as project-openan#61) and 9b, deferred as a separate follow-up — moving the session token out of `localStorage` into an httpOnly cookie. `localStorage` is readable by any script running on the page, so a token stored there is a standing bridge from any XSS to full account takeover; an httpOnly cookie closes that off entirely.

## What changed

**Backend** (`orchestrate/server/auth.py`, `orchestrate/server/frontend_support_server.py`)
- `login` now sets the token via `Response.set_cookie` (`Secure` tied to `enable_https`, `HttpOnly`, `SameSite=Lax`) instead of returning it in the JSON body — returning it there too would defeat the point of `HttpOnly` the moment any script reads the login response.
- `logout` clears the cookie server-side; only the server can, since the frontend can no longer read or write it.
- `extract_token` (promoted from the auth-module-private `_extract_token`, now imported by `frontend_support_server` too rather than each endpoint hand-rolling its own header parsing) reads the cookie first, falls back to `Authorization: Bearer` for non-browser clients (curl, scripts), and **no longer accepts `?access_token=`** — that was the one place a live token still ended up in a URL, which #39 could only redact one layer down (application logs) rather than eliminate (it was still in browser history and any intermediate proxy's access log).
- `CORS_ORIGINS`'s `allow_credentials` is now `True` (required for the cookie to travel on a cross-origin request at all).
- Cookie `Path=/`, not the internal API prefix. This one took a live-topology check to catch: a browser scopes a cookie to the URL it actually requested, and in gateway mode (nginx in docker-compose, Vite's dev proxy for `npm run dev`) that URL carries the `/api/orchestrate` prefix the proxy strips *before* this backend ever sees the request. A narrower `Path=/rest/v1/orchestrate` would never match either browser-visible shape (prefixed or direct-IP), so the browser would silently never send the cookie back — login would 200, and every following request would 401. `tests/test_session_cookie.py` asserts the exact `Path` attribute rather than a substring, specifically so a regression to the narrower scope can't slip back in silently.

**Frontend** (`api.js`, `App.jsx`, `login/index.jsx`, `execution_center/index.jsx`)
- Removed `getAuthToken`/`setAuthToken`/`localStorage` token storage and the `Authorization` request interceptor entirely — there's no token value for this code to see or handle anymore. `axios.create({ withCredentials: true })` and both `EventSource` constructions carry the cookie instead; the `?access_token=` query param is gone from both SSE URL builders.
- `shouldDefaultToGateway()` now always returns `true`. The cookie only attaches on a same-origin request, and `npm run dev` (frontend on `:3003`, backend on `:5001`) was cross-origin by default — it now goes through Vite's existing (previously LAN-only) `/api/orchestrate` proxy instead, matching the same-origin topology docker-compose already has via nginx. Direct-IP mode is still available as an explicit, manually-configured choice in the settings UI.
- Fixed two now-dead checks that would have quietly broken login/logout: `Login`'s success handlers were gating on a `data.token` field that no longer exists in the response body (would never have fired again post-migration); `App.jsx`'s logout handler never actually called the logout API at all — it only cleared the localStorage token, which happened to work as a "forget it client-side" trick under the old scheme but can't work at all against an httpOnly cookie, since only the server can clear it.

## Deliberately out of scope

- CSRF defense beyond `SameSite=Lax` + an explicit `CORS_ORIGINS` allowlist (no double-submit token). Both shipped topologies are same-origin, where `SameSite=Lax` combined with the browser's own same-origin policy already closes the practical cross-site attack surface; a double-submit token would add complexity without a live exposure to justify it here. Worth reconsidering if a legitimate cross-origin deployment (`CORS_ORIGINS` set to a real third-party origin) shows up.
- Session storage remaining single-process/in-memory (`#14`, closed as documentation-only) — unrelated to this token-transport change and already scoped separately.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (describe below)

Breaking: the internal API's `/auth/login` response no longer includes a `token` field (any external script driving the internal API directly via that field would need to switch to relying on the cookie, or the still-supported `Authorization: Bearer` header obtained some other way).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/project-openan/.github/blob/main/CONTRIBUTING.md) guide
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix is effective or my feature works (if applicable)
- [x] I have added or updated documentation as needed
- [x] New source files include the SPDX license header

## Additional Context

Validated locally against `upstream/main`: `pytest tests/ --ignore=tests/test_external_apis.py` — 471 passed, 7 pre-existing skips, 0 failures. 9 new tests in `tests/test_session_cookie.py` (cookie attributes including the `Path` regression guard above, logout clearing it, `extract_token`'s cookie/header/no-more-query-param precedence). Frontend: 40/40 passed, lint 0 errors/31 warnings (unchanged baseline), `npm run build` succeeds.

**Verified at the ASGI/TestClient layer and the frontend unit-test layer only — not in a live browser**, no browser automation was available in this environment. That's explicitly the layer that would have caught the `Path` bug above (found instead by attempting a manual curl-through-the-Vite-proxy smoke test and reasoning through RFC 6265 path-matching), so please don't read the test counts as end-to-end confirmation — a real browser login/logout/SSE-execution pass before merge would be valuable if anyone reviewing has one handy.

Addresses 9b from hw-irc-sni/orchestration-center#9 (9a merged as project-openan#61), one of the sub-issues tracked under the security-hardening umbrella hw-irc-sni/orchestration-center#37.
