### PR TITLE
fix: declare cryptography as a direct dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ pymupdf
 limits>=5.8.0
 python-multipart>=0.0.24
 psycopg2-binary>=2.9.10
+cryptography>=41.0.0
 # Development dependencies (install separately for testing):
 pytest>=8.0
 pytest-asyncio>=0.24


### PR DESCRIPTION
## Summary

- `common/cert/certificate_generator.py` imports `cryptography`'s public API directly (`x509`, `hashes`, `serialization`, `rsa`, `ExtendedKeyUsageOID`), but `requirements.txt` never declared it.
- It currently installs successfully only because `cryptography` is an undeclared transitive dependency of `a2a-sdk`. If that dependency's pin changes, `import common.cert.certificate_generator` (and everything built on it — HTTPS setup, `generate_selfsign_cert.py`) breaks with `ModuleNotFoundError`.
- Added `cryptography>=41.0.0` (floor picked to comfortably predate the API surface actually used; currently resolves to 49.0.0 in this environment).

## Test plan

- [x] Full backend suite (`pytest tests/ --ignore=tests/test_external_apis.py`) — 481 passed, 7 skipped, no regressions