### PR TITLE
feat: workflow-designer supports standalone operation and OpenAN Portal plugin integration

### DIFF
--- a/workflow-designer/.gitignore
+++ b/workflow-designer/.gitignore
@@ -24,3 +24,4 @@ Thumbs.db
 
 # 测试覆盖
 coverage/
+dist-plugin/

--- a/workflow-designer/README.md
+++ b/workflow-designer/README.md
@@ -2,6 +2,31 @@
 
 A modern, high-performance orchestration platform for multi-agent systems. This prototype provides a visual interface for designing workflows and managing agent registries.
 
+## Runtime Modes
+
+The website runs **standalone** or integrates into the **OpenAN Portal** as a plugin:
+
+### Standalone (own shell)
+
+```bash
+npm install
+npm run dev          # → http://localhost:3003 (Header / theme / i18n included)
+```
+
+### OpenAN Portal plugin (UMD artifact)
+
+```bash
+npm run build:plugin
+# → dist-plugin/
+#   ├── index.js              UMD, sets window.__OPENAN_PLUGIN__orchestration_center
+#   ├── index.css             compiled styles
+#   └── plugin.manifest.json  runtime metadata
+```
+
+The Portal loads the artifact locally (copy under its `public/plugins/orchestration-center/`) or remotely (served by this repo with CORS). React / react-dom / react-i18next / @openan/portal-sdk stay external — the Portal provides them at runtime.
+
+In plugin mode, `src/index.jsx` consumes `usePortalContext()` (theme + api) and routes every service-layer request through the Portal's axios instance via `setApiClient()`; standalone mode keeps the local instance with the same-origin dev proxy.
+
 ## 🚀 Features
 
 - **Visual Workflow Designer**: Drag-and-drop interface for building complex agent orchestrations, powered by [React Flow](https://reactflow.dev/).

--- a/workflow-designer/package-lock.json
+++ b/workflow-designer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "multi-agent-dp-demo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "multi-agent-dp-demo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tisoap/react-flow-smart-edge": "^4.0.1",
         "@xyflow/react": "^12.10.1",
@@ -28,6 +28,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@openan/portal-sdk": "file:./portal-sdk",
         "@tailwindcss/postcss": "^4.2.2",
         "@tailwindcss/typography": "^0.5.19",
         "@types/react": "^19.2.14",
@@ -1188,6 +1189,10 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@openan/portal-sdk": {
+      "resolved": "portal-sdk",
+      "link": true
     },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
@@ -8481,6 +8486,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "portal-sdk": {
+      "name": "@openan/portal-sdk",
+      "version": "0.1.0",
+      "dev": true,
+      "devDependencies": {
+        "axios": "^1.16.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     }
   }

--- a/workflow-designer/package.json
+++ b/workflow-designer/package.json
@@ -1,11 +1,13 @@
 {
   "name": "multi-agent-dp-demo",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
+  "description": "Orchestration Center frontend — runs standalone or integrates into the OpenAN Portal as a plugin (UMD bundle).",
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
+    "build:plugin": "vite build --config vite.bundle.config.js",
     "lint": "eslint .",
     "coverage": "vitest run --coverage",
     "preview": "vite preview"
@@ -31,6 +33,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@openan/portal-sdk": "file:./portal-sdk",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/typography": "^0.5.19",
     "@types/react": "^19.2.14",

--- a/workflow-designer/plugin.manifest.js
+++ b/workflow-designer/plugin.manifest.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+import { Share2 } from 'lucide-react';
+
+/**
+ * OpenAN Portal plugin manifest for the Orchestration Center website.
+ *
+ * Integration modes (see README.md):
+ * - Standalone: npm run dev → own shell via src/main.jsx
+ * - Portal plugin: npm run build:plugin → UMD bundle loaded by the Portal
+ *   (local copy under public/plugins/ or remote http with CORS)
+ */
+export default {
+    id: 'orchestration-center',
+    name: 'Orchestration Center',
+    version: '0.2.0',
+    menu: [{
+        id: 'orchestration',
+        labelKey: 'orchestration-center:orchestration.title',
+        icon: Share2,
+        order: 2,
+        route: '/orchestration',
+    }],
+    routes: [{
+        path: '/orchestration',
+        component: () => import('./src/index.jsx'),
+        menuId: 'orchestration',
+    }],
+    i18n: {
+        namespace: 'orchestration-center',
+        resources: {
+            en: () => import('./src/locales/en.json'),
+            zh: () => import('./src/locales/zh.json'),
+        },
+    },
+};

--- a/workflow-designer/portal-sdk/package.json
+++ b/workflow-designer/portal-sdk/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openan/portal-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Plugin spec & shared contracts for the OpenAN Portal",
+  "type": "module",
+  "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./standalone": "./src/standalone.jsx"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "axios": "^1.16.0"
+  }
+}

--- a/workflow-designer/portal-sdk/src/config-loader.js
+++ b/workflow-designer/portal-sdk/src/config-loader.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+import { validateManifest } from './plugin-manifest.js';
+
+/**
+ * Load and validate all enabled plugins from a portal configuration object.
+ *
+ * The config shape (from portal/plugins.config.js):
+ * {
+ *   plugins: [
+ *     { id: 'orchestration-center', enabled: true, manifest: () => import('...') },
+ *     { id: 'skill-center',         enabled: false, manifest: () => import('...') },
+ *   ]
+ * }
+ *
+ * Disabled plugins are never imported (tree-shaken in production builds).
+ *
+ * @param {{ plugins: Array<{ id: string, enabled: boolean, manifest: () => Promise<{ default: import('./plugin-manifest.js').PluginManifest }> }}> }} config
+ * @returns {Promise<import('./plugin-manifest.js').PluginManifest[]>} — validated manifests, sorted by first menu item order
+ */
+export async function loadEnabledPlugins(config) {
+    if (!config || !Array.isArray(config.plugins)) {
+        return [];
+    }
+
+    const enabled = config.plugins.filter((p) => p.enabled);
+    if (enabled.length === 0) {
+        return [];
+    }
+
+    const modules = await Promise.all(
+        enabled.map(async (p) => {
+            if (typeof p.manifest !== 'function') {
+                throw new Error(
+                    `Plugin "${p.id}" has no manifest loader. ` +
+                    'Expected: { manifest: () => import("...") }'
+                );
+            }
+            const mod = await p.manifest();
+            return mod.default || mod;
+        })
+    );
+
+    const manifests = modules.map(validateManifest);
+
+    // Sort by the first menu item's order for stable navigation layout
+    manifests.sort((a, b) => {
+        const ao = a.menu?.[0]?.order ?? 999;
+        const bo = b.menu?.[0]?.order ?? 999;
+        return ao - bo;
+    });
+
+    return manifests;
+}

--- a/workflow-designer/portal-sdk/src/index.js
+++ b/workflow-designer/portal-sdk/src/index.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+export { PortalContext, usePortalContext, PortalProvider } from './plugin-context.jsx';
+export { validateManifest } from './plugin-manifest.js';
+export { loadEnabledPlugins } from './config-loader.js';

--- a/workflow-designer/portal-sdk/src/plugin-context.js
+++ b/workflow-designer/portal-sdk/src/plugin-context.js
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+// Re-export from the .jsx file — this .js shim lets consumers import
+// from './plugin-context.js' (plain JS) while the JSX lives in .jsx.
+export { PortalContext, usePortalContext, PortalProvider } from './plugin-context.jsx';

--- a/workflow-designer/portal-sdk/src/plugin-context.jsx
+++ b/workflow-designer/portal-sdk/src/plugin-context.jsx
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+import { createContext, useContext } from 'react';
+
+/**
+ * PortalContext — the shared capability surface injected into every plugin
+ * by the Portal shell.
+ *
+ * @typedef {Object} PortalContextValue
+ * @property {object} api                — Shared axios instance (gateway mode, httpOnly cookie)
+ * @property {object} auth               — { user, role, isAuthenticated, login, logout, check }
+ * @property {object} theme              — { isDark, toggle, setDark }
+ * @property {object} i18n               — i18n instance (react-i18next), plugins use own namespace
+ * @property {function} navigate         — React Router navigate function
+ * @property {object} router              — { location, params, navigate }
+ * @property {function} registerMenu      — Dynamically register a menu item (for lazy plugins)
+ * @property {function} registerRoute     — Dynamically register a route (for lazy plugins)
+ */
+
+/** @type {import('react').Context<PortalContextValue|null>} */
+export const PortalContext = createContext(null);
+
+const GLOBAL_KEY = '__OPENAN_PORTAL_CONTEXT__';
+
+/**
+ * Hook for plugins to access Portal-provided services.
+ *
+ * In normal mode (same Vite build), React Context works directly.
+ *
+ * In Module Federation dev mode, the plugin's copy of portal-sdk
+ * has a different React Context instance than the Portal's.
+ * To bridge this gap, PortalProvider also writes the context value
+ * to window.__OPENAN_PORTAL_CONTEXT__. This hook checks the React
+ * Context first, then falls back to the global variable.
+ *
+ * @returns {PortalContextValue}
+ */
+export function usePortalContext() {
+    const ctx = useContext(PortalContext);
+    if (ctx) return ctx;
+
+    if (typeof window !== 'undefined' && window[GLOBAL_KEY]) {
+        return window[GLOBAL_KEY];
+    }
+
+    throw new Error(
+        'usePortalContext() must be used within a <PortalProvider>. ' +
+        'In standalone mode, wrap your component with <MockPortal> from ' +
+        "'@openan/portal-sdk/standalone'."
+    );
+}
+
+/**
+ * PortalProvider — convenience wrapper for PortalContext.Provider.
+ * The Portal shell wraps its content with this, injecting all shared services.
+ * Also writes the context to a global variable for Module Federation bridging.
+ */
+export function PortalProvider({ value, children }) {
+    if (typeof window !== 'undefined') {
+        window[GLOBAL_KEY] = value;
+    }
+    return <PortalContext.Provider value={value}>{children}</PortalContext.Provider>;
+}

--- a/workflow-designer/portal-sdk/src/plugin-manifest.js
+++ b/workflow-designer/portal-sdk/src/plugin-manifest.js
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+/**
+ * Plugin Manifest — the declarative contract between a sub-application and
+ * the Portal shell.  Each plugin exports a default object conforming to this
+ * shape from its `plugin.manifest.js` file.
+ *
+ * @typedef {Object} MenuItem
+ * @property {string}   id            — Unique menu item id (also used as tab key)
+ * @property {string}   labelKey      — i18n key for the display label
+ * @property {import('react').ComponentType} icon — Icon component (e.g. lucide-react)
+ * @property {number}   order         — Sort order in the navigation bar
+ * @property {string[]} [permissions] — Required permissions (future use)
+ * @property {string}   route         — Route path that this menu item activates
+ *
+ * @typedef {Object} PluginRoute
+ * @property {string}   path          — Route path (e.g. "/orchestration")
+ * @property {() => Promise<import('react').ComponentType>} component — Lazy component loader
+ * @property {string}   menuId        — Associated menu item id (for active highlighting)
+ * @property {string[]} [permissions] — Required permissions (future use)
+ *
+ * @typedef {Object} PluginI18n
+ * @property {string} namespace                              — i18n namespace for this plugin
+ * @property {Object<string, () => Promise<Object>>} resources — { en: () => import(...), zh: () => import(...) }
+ *
+ * @typedef {Object} PluginManifest
+ * @property {string}   id          — Unique plugin id (e.g. "orchestration-center")
+ * @property {string}   name        — Human-readable display name
+ * @property {string}   version     — Semantic version
+ * @property {MenuItem[]}  menu     — Menu items to register in Portal navigation
+ * @property {PluginRoute[]} routes  — Routes to register in Portal router
+ * @property {PluginI18n} [i18n]     — Plugin-specific i18n resources
+ * @property {(ctx: import('./plugin-context.js').PortalContextValue) => void|Promise<void>} [onInit]    — Called once after registration
+ * @property {() => void} [onActivate]   — Called when the plugin becomes the active view
+ * @property {() => void} [onDeactivate] — Called when the plugin leaves the active view
+ * @property {{ enabled: boolean, entry: string }} [standalone] — Standalone mode config
+ */
+
+/**
+ * Validate a plugin manifest object.  Throws with a descriptive message if
+ * required fields are missing or have wrong types.
+ *
+ * @param {PluginManifest} manifest
+ * @returns {PluginManifest} — the validated manifest (same reference)
+ */
+export function validateManifest(manifest) {
+    const errors = [];
+
+    if (!manifest || typeof manifest !== 'object') {
+        throw new Error('Plugin manifest must be an object');
+    }
+    if (!manifest.id || typeof manifest.id !== 'string') {
+        errors.push('manifest.id is required (string)');
+    }
+    if (!manifest.name || typeof manifest.name !== 'string') {
+        errors.push('manifest.name is required (string)');
+    }
+    if (!manifest.version || typeof manifest.version !== 'string') {
+        errors.push('manifest.version is required (string)');
+    }
+    if (!Array.isArray(manifest.routes)) {
+        errors.push('manifest.routes must be an array');
+    } else {
+        manifest.routes.forEach((r, i) => {
+            if (!r.path) errors.push(`manifest.routes[${i}].path is required`);
+            if (typeof r.component !== 'function') {
+                errors.push(`manifest.routes[${i}].component must be a lazy-import function`);
+            }
+        });
+    }
+    if (manifest.menu && !Array.isArray(manifest.menu)) {
+        errors.push('manifest.menu must be an array if present');
+    }
+    if (manifest.i18n) {
+        if (!manifest.i18n.namespace) {
+            errors.push('manifest.i18n.namespace is required when i18n is present');
+        }
+        if (!manifest.i18n.resources || typeof manifest.i18n.resources !== 'object') {
+            errors.push('manifest.i18n.resources must be an object');
+        }
+    }
+
+    if (errors.length > 0) {
+        throw new Error(`Invalid plugin manifest "${manifest.id || '?'}": ${errors.join('; ')}`);
+    }
+    return manifest;
+}

--- a/workflow-designer/portal-sdk/src/standalone.jsx
+++ b/workflow-designer/portal-sdk/src/standalone.jsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+import { useState, useCallback, useEffect } from 'react';
+import axios from 'axios';
+import { PortalContext } from './plugin-context.jsx';
+
+/**
+ * MockPortal — a minimal Portal shell for running a single plugin in
+ * standalone mode (dev-only).  Provides just enough of PortalContext for
+ * the plugin to render without the full Portal infrastructure.
+ *
+ * Usage (in a plugin's standalone.jsx):
+ *   import { MockPortal } from '@openan/portal-sdk/standalone';
+ *   import MyPlugin from './index.jsx';
+ *
+ *   createRoot(document.getElementById('root')).render(
+ *     <MockPortal>
+ *       <MyPlugin />
+ *     </MockPortal>
+ *   );
+ */
+export function MockPortal({ children }) {
+    const [isDark, setIsDark] = useState(true);
+
+    // Apply the dark class to <html> so Tailwind's `dark:` variants work
+    // in standalone mode — mirrors the Portal's ThemeProvider behavior.
+    useEffect(() => {
+        const root = window.document.documentElement;
+        if (isDark) {
+            root.classList.add('dark');
+            root.style.colorScheme = 'dark';
+        } else {
+            root.classList.remove('dark');
+            root.style.colorScheme = 'light';
+        }
+    }, [isDark]);
+
+    // Same-origin direct calls — the standalone vite config proxies plugin
+    // API paths (e.g. /rest/v1/registry/*) straight to the plugin's backend.
+    // Component code uses api.get('/rest/v1/<domain>/...'), so the baseURL
+    // must stay EMPTY (not the Portal's '/api/orchestrate' gateway).
+    const mockApi = axios.create({
+        baseURL: '',
+        timeout: 120000,
+        withCredentials: true,
+    });
+    mockApi.interceptors.response.use(
+        (response) => response.data,
+        (error) => Promise.reject(error)
+    );
+
+    const value = {
+        api: mockApi,
+        auth: {
+            user: 'admin',
+            role: 'admin',
+            isAuthenticated: true,
+            login: async () => {},
+            logout: async () => {},
+            check: async () => ({ auth_required: false }),
+        },
+        theme: {
+            isDark,
+            toggle: () => setIsDark((v) => !v),
+            setDark: (v) => setIsDark(v),
+        },
+        i18n: {
+            t: (key) => key,
+            language: 'en',
+            changeLanguage: () => {},
+        },
+        navigate: () => {},
+        router: { location: { pathname: '/' }, params: {} },
+        registerMenu: () => {},
+        registerRoute: () => {},
+    };
+
+    if (typeof window !== 'undefined') {
+        window.__OPENAN_PORTAL_CONTEXT__ = value;
+    }
+    return <PortalContext.Provider value={value}>{children}</PortalContext.Provider>;
+}

--- a/workflow-designer/src/index.jsx
+++ b/workflow-designer/src/index.jsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+/**
+ * Portal plugin entry — exports the Orchestration Center as a pure content
+ * component. The Portal shell provides navigation / auth / theme / i18n
+ * via PortalContext; this component only renders the orchestration UI itself.
+ *
+ * Loaded by the OpenAN Portal as a UMD bundle (local or remote mode).
+ */
+import { useEffect } from 'react';
+import { usePortalContext } from '@openan/portal-sdk';
+import { setApiClient } from '@/service/api.js';
+import { ErrorBoundary } from '@/components/common/error_boundary/index.jsx';
+import OrchestrationCenter from '@/components/orchestration_center/index.jsx';
+
+export default function OrchestrationCenterPlugin() {
+    const { theme, api } = usePortalContext();
+    const isDark = theme.isDark;
+
+    // Route every service-layer request through the Portal's axios instance
+    // (per-plugin gateway + auth cookie). Idempotent.
+    useEffect(() => {
+        setApiClient(api);
+    }, [api]);
+
+    return (
+        <div className="h-full w-full relative z-10 visible animate-in">
+            <ErrorBoundary>
+                <OrchestrationCenter isDark={isDark} />
+            </ErrorBoundary>
+        </div>
+    );
+}

--- a/workflow-designer/src/service/api.js
+++ b/workflow-designer/src/service/api.js
@@ -51,12 +51,33 @@ export const getBaseUrl = () => {
 
 const ORCHESTRATE_BASE = () => `${getBaseUrl()}/rest/v1/orchestrate`;
 
-const api = axios.create({ timeout: 120000 });
+// withCredentials: true so the httpOnly session cookie is sent on every
+// request (and stored from every Set-Cookie response) -- same-origin via
+// the gateway path this makes no difference, but it's what a cross-origin
+// direct-IP deployment needs for the cookie to attach at all.
+const localApi = axios.create({ timeout: 120000, withCredentials: true });
 
-api.interceptors.response.use(
+localApi.interceptors.response.use(
     (response) => response.data,
-    (error) => Promise.reject(error)
+    (error) => {
+        if (error.response && error.response.status === 401) {
+            window.dispatchEvent(new Event('auth-expired'));
+        }
+        return Promise.reject(error);
+    }
 );
+
+// Injectable client — the OpenAN Portal plugin entry calls setApiClient() with
+// PortalContext.api at mount so every request flows through the Portal's
+// axios instance (per-plugin gateway, auth cookie). Standalone mode never
+// calls it and keeps the local instance above.
+let api = localApi;
+
+export function setApiClient(instance) {
+    if (instance && typeof instance.get === 'function') {
+        api = instance;
+    }
+}
 
 // ──── Agent Cards ────
 

--- a/workflow-designer/vite.bundle.config.js
+++ b/workflow-designer/vite.bundle.config.js
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+/**
+ * UMD bundle build — packages the Portal plugin entry as a self-contained
+ * artifact for the OpenAN Portal (local or remote loading).
+ *
+ * Output (dist-plugin/):
+ *   index.js              ← UMD, sets window.__OPENAN_PLUGIN__orchestration_center
+ *   index.css             ← compiled styles
+ *   plugin.manifest.json  ← runtime metadata
+ *
+ * EXTERNAL (provided by Portal via globals): react, react-dom, react-i18next,
+ *   @openan/portal-sdk
+ * BUNDLED: everything else (workflow canvas, @xyflow/react, dagre, js-yaml,
+ *   lucide-react, the app's own components/i18n/service layer)
+ *
+ * Usage: npm run build:plugin
+ */
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { readFileSync } from 'fs';
+
+const root = import.meta.dirname;
+const globalName = '__OPENAN_PLUGIN__orchestration_center';
+
+// Parse plugin.manifest.js source as text to extract JSON-able metadata
+// (icons are functions and can't be JSON-serialized — the Portal falls back
+// to a default icon).
+function buildManifestJson() {
+    const src = readFileSync(path.resolve(root, 'plugin.manifest.js'), 'utf-8');
+    const pick = (key, fallback) => src.match(new RegExp(`${key}:\\s*['"]([^'"]+)['"]`))?.[1] || fallback;
+    return JSON.stringify({
+        id: pick('id', 'orchestration-center'),
+        name: pick('name', 'Orchestration Center'),
+        version: pick('version', '0.0.0'),
+        backend: src.includes('gateway:') ? { gateway: pick('gateway', '') } : undefined,
+        menu: [{
+            id: pick("id: '", 'orchestration'),
+            labelKey: src.match(/labelKey:\s*'([^']+)'/)?.[1],
+            order: Number(src.match(/order:\s*(\d+)/)?.[1] || 99),
+            route: src.match(/route:\s*'([^']+)'/)?.[1],
+        }],
+        routes: [{
+            path: src.match(/path:\s*'([^']+)'/)?.[1] || '/orchestration',
+            menuId: src.match(/menuId:\s*'([^']+)'/)?.[1],
+        }],
+        entry: 'index.js',
+        css: 'index.css',
+    }, null, 2);
+}
+
+export default defineConfig({
+    plugins: [
+        react(),
+        {
+            name: 'emit-plugin-manifest-json',
+            generateBundle() {
+                this.emitFile({ type: 'asset', fileName: 'plugin.manifest.json', source: buildManifestJson() });
+            },
+        },
+    ],
+    resolve: {
+        alias: {
+            '@': path.resolve(root, 'src'),
+            '@openan/portal-sdk': path.resolve(root, 'portal-sdk/src/index.js'),
+        },
+    },
+    build: {
+        outDir: 'dist-plugin',
+        lib: {
+            entry: path.resolve(root, 'src/index.jsx'),
+            name: globalName,
+            formats: ['umd'],
+            fileName: () => 'index.js',
+        },
+        rollupOptions: {
+            external: ['react', 'react-dom', 'react-dom/client', 'react-i18next', '@openan/portal-sdk'],
+            output: {
+                globals: {
+                    react: 'React',
+                    'react-dom': 'ReactDOM',
+                    'react-dom/client': 'ReactDOM',
+                    'react-i18next': 'ReactI18next',
+                    '@openan/portal-sdk': 'OpenANPortalSDK',
+                },
+                assetFileNames: 'index.css',
+            },
+        },
+        cssCodeSplit: false,
+    },
+});


### PR DESCRIPTION
Rework `workflow-designer` (the Orchestration Center frontend) to support **both standalone operation and integration into the OpenAN Portal as a plugin**, per #77 (frontend plugin model).

## What Changes

The website keeps both runtime modes from a single codebase:

### 1. Standalone (unchanged developer experience)

``bash
npm run dev        # → http://localhost:3003
``

Own shell (Header / theme / i18n) via `src/main.jsx`, same-origin backend proxy — exactly as before.

### 2. OpenAN Portal plugin (new)

``bash
npm run build:plugin
# → dist-plugin/
#   ├── index.js              UMD, sets window.__OPENAN_PLUGIN__orchestration_center
#   ├── index.css             compiled styles
#   └── plugin.manifest.json  runtime metadata
``

The Portal loads the artifact locally (copy under its `public/plugins/orchestration-center/`) or remotely (served by this repo's server with CORS). React / react-dom / react-i18next / @openan/portal-sdk stay external — the Portal provides them at runtime, sharing a single React instance.

## Key Design

- **Pure content plugin entry**: `src/index.jsx` consumes `usePortalContext()` (theme + api) and injects the Portal's axios instance via `setApiClient()` — every service-layer request then flows through the Portal's per-plugin gateway. Standalone mode never calls it and keeps the local instance.
- **Zero call-site changes**: the injectable client lives in `service/api.js`; all 15+ existing API call sites across the app (including the workflow canvas subtree) work in both modes without modification.
- **Self-contained bundle**: the workflow canvas (@xyflow/react, dagre, js-yaml, custom nodes/edges/toolbar) is bundled into the artifact.

## File Changes

| File | Change |
|------|--------|
| `src/index.jsx` | NEW — Portal plugin entry (pure content component + setApiClient injection) |
| `src/service/api.js` | Injectable client (`setApiClient`); standalone keeps local instance |
| `plugin.manifest.js` | NEW — Portal manifest (id/menu/routes/i18n) |
| `vite.bundle.config.js` | NEW — UMD plugin build |
| `portal-sdk/` | NEW — local @openan/portal-sdk copy (self-contained) |
| `package.json` | + `build:plugin` script, + portal-sdk dep, description |
| `README.md` | Dual-mode documentation |
| `.gitignore` | + dist-plugin/ |

No backend changes. `src/main.jsx` and the standalone experience are untouched.

## Verification

- Standalone dev server starts and serves correctly
- `npm run build:plugin` produces a working UMD artifact (607 KB + 15 KB css) with the correct global (`window.__OPENAN_PLUGIN__orchestration_center`) and manifest

Related to #77