### PR TITLE
fix(tls): validate certificate subject alternative names

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,8 +391,21 @@ python generate_access_password.py
 
 Generate self-signed certificates (RSA 3072, compliant with cert validator):
 ```bash
-python generate_selfsign_cert.py etc/ssl serverAuth
+python -m generate_selfsign_cert etc/ssl serverAuth
 ```
+
+New TLS certificates include SANs for `DNS:localhost`, `IP:127.0.0.1` and `IP:::1` by default.
+For other endpoints, repeat `--dns` / `--ip` for the actual client-facing names; explicit options replace the default SAN list:
+
+```bash
+python -m generate_selfsign_cert etc/ssl-new serverAuth --dns orch.example.test --ip 192.0.2.10
+```
+
+SANs must match the host in the client URL; IP addresses require `--ip`. Setting CN or trusting a certificate does not fix missing SANs.
+Existing certificates are not updated automatically, and the tool refuses to overwrite certificates or private keys.
+For an existing deployment, generate into a new directory, back up and deploy the matching certificate/key pair, then restart.
+Update client trust material where required; do not overwrite the CA store used to authenticate clients.
+`dataSigning` does not add TLS SANs and rejects CLI SAN options.
 
 **Enabling HTTPS (step by step):**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -317,8 +317,20 @@ python generate_access_password.py
 
 生成自签名证书（RSA 3072，满足证书校验要求）：
 ```bash
-python generate_selfsign_cert.py etc/ssl serverAuth
+python -m generate_selfsign_cert etc/ssl serverAuth
 ```
+
+新生成的 TLS 证书默认带 SAN：`DNS:localhost`、`IP:127.0.0.1`、`IP:::1`。
+部署到其他地址时，用可重复的 `--dns` / `--ip` 指定实际访问地址；显式选项会替换默认 SAN 列表：
+
+```bash
+python -m generate_selfsign_cert etc/ssl-new serverAuth --dns orch.example.test --ip 192.0.2.10
+```
+
+SAN 必须与客户端 URL 的主机匹配，IP 必须使用 `--ip`，仅设置 CN 或信任证书不能解决 SAN 缺失。
+旧证书不会自动更新；工具拒绝覆盖已有证书或私钥。已有部署请在新目录生成，备份并部署匹配的
+证书/私钥后重启服务；需要重新分发信任证书的客户端应同步更新。不要覆盖用于校验客户端身份的 CA 信任库。
+`dataSigning` 不添加 TLS SAN，也不接受命令行 SAN 选项。
 
 **启用 HTTPS 步骤：**
 

--- a/common/cert/certificate_generator.py
+++ b/common/cert/certificate_generator.py
@@ -16,7 +16,9 @@
 #    under the License.
 
 import datetime
+import ipaddress
 import os
+import re
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
@@ -36,10 +38,37 @@ class CertificateGenerator:
     ISSUER = "orchestration-center"
     SUBJECT = "orchestration-center"
 
-    def __init__(self, key_algorithm: str = 'RSA'):
+    def __init__(self, key_algorithm: str = 'RSA', *,
+                 dns_names: list[str] | None = None, ip_addresses: list[str] | None = None):
+        """Use loopback SANs by default; explicit lists replace the complete SAN set."""
         self.key_algorithm = key_algorithm
         self.password_generator = PasswordGenerator()
         self.alg = key_algorithm
+        local_defaults = dns_names is None and ip_addresses is None
+        self.dns_names = ["localhost"] if local_defaults else list(dns_names or [])
+        self.ip_addresses = ["127.0.0.1", "::1"] if local_defaults else list(ip_addresses or [])
+
+    def _server_san(self) -> x509.SubjectAlternativeName:
+        names = []
+        for value in self.dns_names:
+            name = value.rstrip(".").encode("idna").decode("ascii").lower()
+            labels = name.split(".")
+            if labels[0] == "*":
+                labels = labels[1:]
+            if not labels or len(name) > 253 or any(
+                    not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", label)
+                    for label in labels):
+                raise ValueError("DNS SAN must be a hostname, not a URL or host:port")
+            try:
+                ipaddress.ip_address(name)
+            except ValueError:
+                names.append(x509.DNSName(name))
+            else:
+                raise ValueError("IP addresses must use ip_addresses / --ip, not DNS SAN")
+        names.extend(x509.IPAddress(ipaddress.ip_address(value)) for value in self.ip_addresses)
+        if not names:
+            raise ValueError("A serverAuth certificate requires at least one DNS or IP SAN")
+        return x509.SubjectAlternativeName(list(dict.fromkeys(names)))
 
     def generate_self_signed_cert(self, cert_dir: str, cert_usage: str, password: str) -> bool:
         """
@@ -50,6 +79,10 @@ class CertificateGenerator:
         :return: True on success, False on failure. False if certificates already exist in the target directory.
         """
         try:
+            if cert_usage not in ("serverAuth", "dataSigning"):
+                raise ValueError("Certificate usage must be serverAuth or dataSigning")
+            if cert_usage == "serverAuth":
+                self._server_san()  # Validate before creating files or generating a private key.
             if self._check_self_signed_certificates_exists(cert_dir):
                 return False
 
@@ -71,7 +104,7 @@ class CertificateGenerator:
 
     def _check_self_signed_certificates_exists(self, cert_dir: str) -> bool:
         cert_file = f"server_{self.alg}.cer"
-        key_file = f"server_key_{self.alg}.cer"
+        key_file = f"server_key_{self.alg}.pem"
         cert_path = os.path.join(cert_dir, cert_file)
         key_path = os.path.join(cert_dir, key_file)
         return os.path.exists(cert_path) or os.path.exists(key_path)
@@ -128,6 +161,7 @@ class CertificateGenerator:
                 x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
                 critical=False
             )
+            builder = builder.add_extension(self._server_san(), critical=False)
 
         builder = builder.add_extension(
             x509.BasicConstraints(ca=False, path_length=None),
@@ -155,7 +189,7 @@ class CertificateGenerator:
 
     def _set_self_signed_file_permissions(self, cert_dir: str) -> None:
         cert_file = f"server_{self.alg}.cer"
-        key_file = f"server_key_{self.alg}.cer"
+        key_file = f"server_key_{self.alg}.pem"
 
         cert_path = os.path.join(cert_dir, cert_file)
         key_path = os.path.join(cert_dir, key_file)

--- a/docs/en/Orchestration Center Development Guide.md
+++ b/docs/en/Orchestration Center Development Guide.md
@@ -618,8 +618,21 @@ Certificate validation requirements (in `common/cert/cert_validater.py`):
 
 Generate compliant self-signed certificates:
 ```bash
-python generate_selfsign_cert.py etc/ssl serverAuth
+python -m generate_selfsign_cert etc/ssl serverAuth
 ```
+
+New TLS certificates include SANs for `DNS:localhost`, `IP:127.0.0.1` and `IP:::1` by default.
+For other endpoints, repeat `--dns` / `--ip` for the actual client-facing names; explicit options replace the default SAN list:
+
+```bash
+python -m generate_selfsign_cert etc/ssl-new serverAuth --dns orch.example.test --ip 192.0.2.10
+```
+
+SANs must match the host in the client URL; IP addresses require `--ip`. Setting CN or trusting a certificate does not fix missing SANs.
+Existing certificates are not updated automatically, and the tool refuses to overwrite certificates or private keys.
+For an existing deployment, generate into a new directory, back up and deploy the matching certificate/key pair, then restart.
+Update client trust material where required; do not overwrite the CA store used to authenticate clients.
+`dataSigning` does not add TLS SANs and rejects CLI SAN options.
 
 **Enabling HTTPS (step by step):**
 

--- a/docs/en/Orchestration Center User Guide.md
+++ b/docs/en/Orchestration Center User Guide.md
@@ -311,8 +311,21 @@ All services must present valid certificates signed by a trusted CA during TLS h
 For development or internal testing:
 
 ```bash
-python generate_selfsign_cert.py etc/ssl serverAuth
+python -m generate_selfsign_cert etc/ssl serverAuth
 ```
+
+New TLS certificates include SANs for `DNS:localhost`, `IP:127.0.0.1` and `IP:::1` by default.
+For other endpoints, repeat `--dns` / `--ip` for the actual client-facing names; explicit options replace the default SAN list:
+
+```bash
+python -m generate_selfsign_cert etc/ssl-new serverAuth --dns orch.example.test --ip 192.0.2.10
+```
+
+SANs must match the host in the client URL; IP addresses require `--ip`. Setting CN or trusting a certificate does not fix missing SANs.
+Existing certificates are not updated automatically, and the tool refuses to overwrite certificates or private keys.
+For an existing deployment, generate into a new directory, back up and deploy the matching certificate/key pair, then restart.
+Update client trust material where required; do not overwrite the CA store used to authenticate clients.
+`dataSigning` does not add TLS SANs and rejects CLI SAN options.
 
 This generates RSA 3072-bit certificates that comply with the built-in certificate validator. Copy the generated files to the expected names:
 

--- a/docs/zh/开发指南.md
+++ b/docs/zh/开发指南.md
@@ -626,8 +626,20 @@ except ValueError:
 
 生成合规的自签名证书：
 ```bash
-python generate_selfsign_cert.py etc/ssl serverAuth
+python -m generate_selfsign_cert etc/ssl serverAuth
 ```
+
+新生成的 TLS 证书默认带 SAN：`DNS:localhost`、`IP:127.0.0.1`、`IP:::1`。
+部署到其他地址时，用可重复的 `--dns` / `--ip` 指定实际访问地址；显式选项会替换默认 SAN 列表：
+
+```bash
+python -m generate_selfsign_cert etc/ssl-new serverAuth --dns orch.example.test --ip 192.0.2.10
+```
+
+SAN 必须与客户端 URL 的主机匹配，IP 必须使用 `--ip`，仅设置 CN 或信任证书不能解决 SAN 缺失。
+旧证书不会自动更新；工具拒绝覆盖已有证书或私钥。已有部署请在新目录生成，备份并部署匹配的
+证书/私钥后重启服务；需要重新分发信任证书的客户端应同步更新。不要覆盖用于校验客户端身份的 CA 信任库。
+`dataSigning` 不添加 TLS SAN，也不接受命令行 SAN 选项。
 
 **启用 HTTPS 步骤：**
 

--- a/docs/zh/用户指南.md
+++ b/docs/zh/用户指南.md
@@ -311,8 +311,20 @@ persistence_mode=postgresql
 用于开发或内部测试：
 
 ```bash
-python generate_selfsign_cert.py etc/ssl serverAuth
+python -m generate_selfsign_cert etc/ssl serverAuth
 ```
+
+新生成的 TLS 证书默认带 SAN：`DNS:localhost`、`IP:127.0.0.1`、`IP:::1`。
+部署到其他地址时，用可重复的 `--dns` / `--ip` 指定实际访问地址；显式选项会替换默认 SAN 列表：
+
+```bash
+python -m generate_selfsign_cert etc/ssl-new serverAuth --dns orch.example.test --ip 192.0.2.10
+```
+
+SAN 必须与客户端 URL 的主机匹配，IP 必须使用 `--ip`，仅设置 CN 或信任证书不能解决 SAN 缺失。
+旧证书不会自动更新；工具拒绝覆盖已有证书或私钥。已有部署请在新目录生成，备份并部署匹配的
+证书/私钥后重启服务；需要重新分发信任证书的客户端应同步更新。不要覆盖用于校验客户端身份的 CA 信任库。
+`dataSigning` 不添加 TLS SAN，也不接受命令行 SAN 选项。
 
 生成 RSA 3072 位证书，满足内置证书校验要求。复制为配置期望的文件名：
 

--- a/generate_selfsign_cert.py
+++ b/generate_selfsign_cert.py
@@ -19,23 +19,27 @@
 """Standalone self-signed certificate generation tool for the orchestration center.
 
 Usage:
-    python generate_selfsign_cert.py <cert_dir> <cert_usage>
+    python -m generate_selfsign_cert <cert_dir> <cert_usage> [--dns HOST] [--ip ADDRESS]
 
     cert_dir:   Certificate directory path
     cert_usage: serverAuth (TLS communication) or dataSigning (data signing)
 
 The password for the private key is entered interactively.
+serverAuth defaults to localhost, 127.0.0.1 and ::1; explicit SAN options replace these defaults.
 """
 
+import argparse
 import sys
 
 from common.cert.certificate_generator import CertificateGenerator
 from common.util.password_util import input_password_with_validation
 
 
-def generate_self_signed_cert(cert_dir: str, cert_usage: str, password: str) -> bool:
+def generate_self_signed_cert(cert_dir: str, cert_usage: str, password: str, *,
+                              dns_names: list[str] | None = None,
+                              ip_addresses: list[str] | None = None) -> bool:
     try:
-        generator = CertificateGenerator(key_algorithm='RSA')
+        generator = CertificateGenerator(key_algorithm='RSA', dns_names=dns_names, ip_addresses=ip_addresses)
         success = generator.generate_self_signed_cert(cert_dir, cert_usage, password)
 
         if success:
@@ -52,22 +56,19 @@ def generate_self_signed_cert(cert_dir: str, cert_usage: str, password: str) -> 
 
 
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: python generate_selfsign_cert.py <cert_dir> <cert_usage>")
-        print("  cert_dir: Certificate directory path")
-        print("  cert_usage: Certificate usage (serverAuth or dataSigning)")
-        sys.exit(1)
-
-    cert_dir = sys.argv[1]
-    cert_usage = sys.argv[2]
-
-    if cert_usage not in ["serverAuth", "dataSigning"]:
-        print("Error: cert_usage must be 'serverAuth' or 'dataSigning'")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cert_dir", help="New certificate directory; existing files are not overwritten")
+    parser.add_argument("cert_usage", choices=("serverAuth", "dataSigning"))
+    parser.add_argument("--dns", action="append", help="DNS SAN; repeat for multiple hostnames")
+    parser.add_argument("--ip", action="append", help="IP SAN; repeat for IPv4 or IPv6 addresses")
+    args = parser.parse_args()
+    if args.cert_usage == "dataSigning" and (args.dns or args.ip):
+        parser.error("--dns and --ip apply only to serverAuth certificates")
 
     password = input_password_with_validation("Enter private key password")
 
-    if generate_self_signed_cert(cert_dir, cert_usage, password):
+    if generate_self_signed_cert(args.cert_dir, args.cert_usage, password,
+                                 dns_names=args.dns, ip_addresses=args.ip):
         sys.exit(0)
     else:
         sys.exit(1)

--- a/tests/test_certificate_san.py
+++ b/tests/test_certificate_san.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Certificate identity and real TLS handshake regressions; no external services."""
+
+import ipaddress
+import socket
+import ssl
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from cryptography import x509
+
+from common.cert.certificate_generator import CertificateGenerator
+
+
+PASSWORD = "Test-only!Password1"
+
+
+def read_san(directory):
+    cert = x509.load_pem_x509_certificate((directory / "server_RSA.cer").read_bytes())
+    return cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+
+
+def test_default_sans_cover_loopback(tmp_path):
+    assert CertificateGenerator().generate_self_signed_cert(str(tmp_path), "serverAuth", PASSWORD)
+    san = read_san(tmp_path)
+    assert san.get_values_for_type(x509.DNSName) == ["localhost"]
+    assert san.get_values_for_type(x509.IPAddress) == [ipaddress.ip_address("127.0.0.1"), ipaddress.ip_address("::1")]
+
+
+def test_explicit_sans_replace_defaults_and_deduplicate(tmp_path):
+    generator = CertificateGenerator(dns_names=["ORCH.example.test", "orch.example.test"],
+                                     ip_addresses=["192.0.2.10", "2001:db8::1"])
+    assert generator.generate_self_signed_cert(str(tmp_path), "serverAuth", PASSWORD)
+    san = read_san(tmp_path)
+    assert san.get_values_for_type(x509.DNSName) == ["orch.example.test"]
+    assert san.get_values_for_type(x509.IPAddress) == [ipaddress.ip_address("192.0.2.10"), ipaddress.ip_address("2001:db8::1")]
+
+
+@pytest.mark.parametrize("settings", [
+    {"dns_names": []}, {"dns_names": ["https://localhost:5001"]},
+    {"dns_names": ["127.0.0.1"]}, {"dns_names": ["bad name"]},
+    {"ip_addresses": ["999.1.1.1"]}, {"ip_addresses": ["localhost"]},
+])
+def test_invalid_sans_do_not_write_credentials(tmp_path, settings):
+    assert not CertificateGenerator(**settings).generate_self_signed_cert(str(tmp_path), "serverAuth", PASSWORD)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_data_signing_has_no_server_identity_extension(tmp_path):
+    assert CertificateGenerator().generate_self_signed_cert(str(tmp_path), "dataSigning", PASSWORD)
+    with pytest.raises(x509.ExtensionNotFound):
+        read_san(tmp_path)
+
+
+def test_existing_private_key_alone_is_never_overwritten(tmp_path):
+    key = tmp_path / "server_key_RSA.pem"
+    key.write_bytes(b"existing-private-key-placeholder")
+    assert not CertificateGenerator().generate_self_signed_cert(str(tmp_path), "serverAuth", PASSWORD)
+    assert key.read_bytes() == b"existing-private-key-placeholder"
+    assert not (tmp_path / "server_RSA.cer").exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission bits do not represent Windows ACLs")
+def test_private_key_permissions_are_restricted(tmp_path):
+    assert CertificateGenerator().generate_self_signed_cert(str(tmp_path), "serverAuth", PASSWORD)
+    assert (tmp_path / "server_key_RSA.pem").stat().st_mode & 0o777 == 0o600
+
+
+def test_cli_passes_explicit_sans_to_generator(tmp_path, monkeypatch):
+    import generate_selfsign_cert as cli
+
+    monkeypatch.setattr(sys, "argv", ["generate_selfsign_cert", str(tmp_path), "serverAuth",
+                                     "--dns", "orch.example.test", "--ip", "192.0.2.10"])
+    monkeypatch.setattr(cli, "input_password_with_validation", lambda prompt: PASSWORD)
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
+    assert exit_info.value.code == 0
+    assert read_san(tmp_path).get_values_for_type(x509.DNSName) == ["orch.example.test"]
+    assert read_san(tmp_path).get_values_for_type(x509.IPAddress) == [ipaddress.ip_address("192.0.2.10")]
+
+
+def test_cli_rejects_sans_for_data_signing_before_password_prompt(tmp_path, monkeypatch):
+    import generate_selfsign_cert as cli
+
+    monkeypatch.setattr(sys, "argv", ["generate_selfsign_cert", str(tmp_path), "dataSigning", "--dns", "localhost"])
+    monkeypatch.setattr(cli, "input_password_with_validation", lambda prompt: pytest.fail("unexpected password prompt"))
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
+    assert exit_info.value.code == 2
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.fixture
+def tls_endpoint(tmp_path):
+    assert CertificateGenerator().generate_self_signed_cert(str(tmp_path), "serverAuth", PASSWORD)
+    certificate = tmp_path / "server_RSA.cer"
+    server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_context.load_cert_chain(certificate, tmp_path / "server_key_RSA.pem", PASSWORD)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server.socket = server_context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.05}, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address, ssl.create_default_context(cafile=str(certificate))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+
+
+@pytest.mark.parametrize("hostname", ["127.0.0.1", "localhost", "::1"])
+def test_real_tls_validates_certificate_chain_and_hostname(tls_endpoint, hostname):
+    address, context = tls_endpoint
+    assert context.check_hostname and context.verify_mode == ssl.CERT_REQUIRED
+    with socket.create_connection(address, timeout=3) as tcp:
+        with context.wrap_socket(tcp, server_hostname=hostname) as tls:
+            tls.sendall(b"GET / HTTP/1.0\r\nHost: localhost\r\n\r\n")
+            assert tls.recv(1024).startswith(b"HTTP/1.0 200")
+
+
+def test_real_tls_still_rejects_an_unlisted_ip(tls_endpoint):
+    address, context = tls_endpoint
+    with socket.create_connection(address, timeout=3) as tcp:
+        with pytest.raises(ssl.SSLCertVerificationError, match="IP address mismatch"):
+            context.wrap_socket(tcp, server_hostname="127.0.0.2")


### PR DESCRIPTION
Closes #92

## Summary

Two commits:

- fix(tls): generate server certificates with validated subject alternatives - DNS SANs must be hostnames (URLs and host:port forms are rejected), IP addresses must go through the dedicated ip_addresses/--ip option, and a serverAuth certificate requires at least one DNS or IP SAN. Loopback SANs (localhost, 127.0.0.1, ::1) apply by default; explicit SAN lists replace them entirely. SAN validation runs before any file creation or key generation. Adds 152 lines of SAN tests.
- docs(tls): explain SAN configuration and certificate replacement - user and development guides, English and Chinese.

## Testing

- `tests/test_certificate_san.py` covers valid hostnames, defaulted loopback SANs, and each rejection case (URL as DNS SAN, host:port, IP in DNS SAN, serverAuth without SANs).
- Existing certificate tests continue to pass.